### PR TITLE
API improvement + bugfix

### DIFF
--- a/examples/low-level/producer/main.go
+++ b/examples/low-level/producer/main.go
@@ -24,9 +24,7 @@ func passAll(enc.Name, enc.Wire, ndn.Signature) bool {
 	return true
 }
 
-func onInterest(
-	interest ndn.Interest, rawInterest enc.Wire, sigCovered enc.Wire, reply ndn.ReplyFunc, deadline time.Time,
-) {
+func onInterest(interest ndn.Interest, reply ndn.ReplyFunc, extra ndn.InterestHandlerExtra) {
 	fmt.Printf(">> I: %s\n", interest.Name().String())
 	content := []byte("Hello, world!")
 

--- a/examples/schema-test/shared-doc/crdt/zz_generated.go
+++ b/examples/schema-test/shared-doc/crdt/zz_generated.go
@@ -132,10 +132,11 @@ func (context *IDTypeParsingContext) Parse(reader enc.ParseReader, ignoreCritica
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 161:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.Producer = uint64(0)
 					{
@@ -153,7 +154,7 @@ func (context *IDTypeParsingContext) Parse(reader enc.ParseReader, ignoreCritica
 					}
 				}
 			case 163:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					value.Clock = uint64(0)
 					{
@@ -190,15 +191,7 @@ func (context *IDTypeParsingContext) Parse(reader enc.ParseReader, ignoreCritica
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 2; progress++ {
-		switch progress {
-		case 0 - 1:
-			err = enc.ErrSkipRequired{Name: "Producer", TypeNum: 161}
-		case 1 - 1:
-			err = enc.ErrSkipRequired{Name: "Clock", TypeNum: 163}
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -490,10 +483,11 @@ func (context *RecordParsingContext) Parse(reader enc.ParseReader, ignoreCritica
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 165:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.RecordType = uint64(0)
 					{
@@ -511,22 +505,22 @@ func (context *RecordParsingContext) Parse(reader enc.ParseReader, ignoreCritica
 					}
 				}
 			case 167:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					value.ID, err = context.ID_context.Parse(reader.Delegate(int(l)), ignoreCritical)
 				}
 			case 169:
-				if progress+1 == 2 {
+				if true {
 					handled = true
 					value.Origin, err = context.Origin_context.Parse(reader.Delegate(int(l)), ignoreCritical)
 				}
 			case 170:
-				if progress+1 == 3 {
+				if true {
 					handled = true
 					value.RightOrigin, err = context.RightOrigin_context.Parse(reader.Delegate(int(l)), ignoreCritical)
 				}
 			case 172:
-				if progress+1 == 4 {
+				if true {
 					handled = true
 					{
 						var builder strings.Builder
@@ -563,21 +557,7 @@ func (context *RecordParsingContext) Parse(reader enc.ParseReader, ignoreCritica
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 5; progress++ {
-		switch progress {
-		case 0 - 1:
-			err = enc.ErrSkipRequired{Name: "RecordType", TypeNum: 165}
-		case 1 - 1:
-			value.ID = nil
-		case 2 - 1:
-			value.Origin = nil
-		case 3 - 1:
-			value.RightOrigin = nil
-		case 4 - 1:
-			err = enc.ErrSkipRequired{Name: "Content", TypeNum: 172}
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/engine/basic/default_engine.go
+++ b/pkg/engine/basic/default_engine.go
@@ -112,6 +112,7 @@ func (e *Engine) DetachHandler(prefix enc.Name) error {
 func (e *Engine) onPacket(reader enc.ParseReader) error {
 	var nackReason uint64 = spec.NackReasonNone
 	var pitToken []byte = nil
+	var incomingFaceId *uint64 = nil
 	var raw enc.Wire = nil
 
 	if e.log.Level <= log.DebugLevel {
@@ -154,6 +155,7 @@ func (e *Engine) onPacket(reader enc.ParseReader) error {
 			nackReason = lpPkt.Nack.Reason
 		}
 		pitToken = lpPkt.PitToken
+		incomingFaceId = lpPkt.IncomingFaceId
 	} else {
 		raw = reader.Range(0, reader.Length())
 	}
@@ -174,9 +176,10 @@ func (e *Engine) onPacket(reader enc.ParseReader) error {
 			e.log.WithField("name", nameStr).Info("Interest received.")
 		}
 		e.onInterest(pkt.Interest, ndn.InterestHandlerExtra{
-			RawInterest: raw,
-			SigCovered:  ctx.Interest_context.SigCovered(),
-			PitToken:    pitToken,
+			RawInterest:    raw,
+			SigCovered:     ctx.Interest_context.SigCovered(),
+			PitToken:       pitToken,
+			IncomingFaceId: incomingFaceId,
 		})
 	} else if pkt.Data != nil {
 		if e.log.Level <= log.InfoLevel {

--- a/pkg/engine/basic/engine_test.go
+++ b/pkg/engine/basic/engine_test.go
@@ -270,12 +270,12 @@ func TestRoute(t *testing.T) {
 		spec := engine.Spec()
 
 		handler := func(
-			interest ndn.Interest, rawInterest enc.Wire, sigCovered enc.Wire, reply ndn.ReplyFunc, deadline time.Time,
+			interest ndn.Interest, reply ndn.ReplyFunc, extra ndn.InterestHandlerExtra,
 		) {
 			hitCnt += 1
 			require.Equal(t, []byte(
 				"\x05\x15\x07\x10\x08\x03not\x08\timportant\x0c\x01\x05",
-			), rawInterest.Join())
+			), extra.RawInterest.Join())
 			require.True(t, interest.Signature().SigType() == ndn.SignatureNone)
 			data, _, err := spec.MakeData(
 				interest.Name(),
@@ -306,7 +306,7 @@ func TestPitToken(t *testing.T) {
 		spec := engine.Spec()
 
 		handler := func(
-			interest ndn.Interest, rawInterest enc.Wire, sigCovered enc.Wire, reply ndn.ReplyFunc, deadline time.Time,
+			interest ndn.Interest, reply ndn.ReplyFunc, extra ndn.InterestHandlerExtra,
 		) {
 			hitCnt += 1
 			data, _, err := spec.MakeData(

--- a/pkg/ndn/mgmt_2022/zz_generated.go
+++ b/pkg/ndn/mgmt_2022/zz_generated.go
@@ -114,10 +114,11 @@ func (context *StrategyParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 7:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.Name = make(enc.Name, l/2+1)
 					startName := reader.Pos()
@@ -159,13 +160,7 @@ func (context *StrategyParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 1; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.Name = nil
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -893,10 +888,11 @@ func (context *ControlArgsParsingContext) Parse(reader enc.ParseReader, ignoreCr
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 7:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.Name = make(enc.Name, l/2+1)
 					startName := reader.Pos()
@@ -921,7 +917,7 @@ func (context *ControlArgsParsingContext) Parse(reader enc.ParseReader, ignoreCr
 
 				}
 			case 105:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -944,7 +940,7 @@ func (context *ControlArgsParsingContext) Parse(reader enc.ParseReader, ignoreCr
 
 				}
 			case 114:
-				if progress+1 == 2 {
+				if true {
 					handled = true
 					{
 						var builder strings.Builder
@@ -957,7 +953,7 @@ func (context *ControlArgsParsingContext) Parse(reader enc.ParseReader, ignoreCr
 
 				}
 			case 129:
-				if progress+1 == 3 {
+				if true {
 					handled = true
 					{
 						var builder strings.Builder
@@ -970,7 +966,7 @@ func (context *ControlArgsParsingContext) Parse(reader enc.ParseReader, ignoreCr
 
 				}
 			case 111:
-				if progress+1 == 4 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -993,7 +989,7 @@ func (context *ControlArgsParsingContext) Parse(reader enc.ParseReader, ignoreCr
 
 				}
 			case 106:
-				if progress+1 == 5 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -1016,7 +1012,7 @@ func (context *ControlArgsParsingContext) Parse(reader enc.ParseReader, ignoreCr
 
 				}
 			case 131:
-				if progress+1 == 6 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -1039,7 +1035,7 @@ func (context *ControlArgsParsingContext) Parse(reader enc.ParseReader, ignoreCr
 
 				}
 			case 132:
-				if progress+1 == 7 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -1062,7 +1058,7 @@ func (context *ControlArgsParsingContext) Parse(reader enc.ParseReader, ignoreCr
 
 				}
 			case 135:
-				if progress+1 == 8 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -1085,7 +1081,7 @@ func (context *ControlArgsParsingContext) Parse(reader enc.ParseReader, ignoreCr
 
 				}
 			case 136:
-				if progress+1 == 9 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -1108,7 +1104,7 @@ func (context *ControlArgsParsingContext) Parse(reader enc.ParseReader, ignoreCr
 
 				}
 			case 137:
-				if progress+1 == 10 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -1131,7 +1127,7 @@ func (context *ControlArgsParsingContext) Parse(reader enc.ParseReader, ignoreCr
 
 				}
 			case 108:
-				if progress+1 == 11 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -1154,7 +1150,7 @@ func (context *ControlArgsParsingContext) Parse(reader enc.ParseReader, ignoreCr
 
 				}
 			case 112:
-				if progress+1 == 12 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -1177,12 +1173,12 @@ func (context *ControlArgsParsingContext) Parse(reader enc.ParseReader, ignoreCr
 
 				}
 			case 107:
-				if progress+1 == 13 {
+				if true {
 					handled = true
 					value.Strategy, err = context.Strategy_context.Parse(reader.Delegate(int(l)), ignoreCritical)
 				}
 			case 109:
-				if progress+1 == 14 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -1205,7 +1201,7 @@ func (context *ControlArgsParsingContext) Parse(reader enc.ParseReader, ignoreCr
 
 				}
 			case 133:
-				if progress+1 == 15 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -1275,43 +1271,7 @@ func (context *ControlArgsParsingContext) Parse(reader enc.ParseReader, ignoreCr
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 16; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.Name = nil
-		case 1 - 1:
-			value.FaceId = nil
-		case 2 - 1:
-			value.Uri = nil
-		case 3 - 1:
-			value.LocalUri = nil
-		case 4 - 1:
-			value.Origin = nil
-		case 5 - 1:
-			value.Cost = nil
-		case 6 - 1:
-			value.Capacity = nil
-		case 7 - 1:
-			value.Count = nil
-		case 8 - 1:
-			value.BaseCongestionMarkInterval = nil
-		case 9 - 1:
-			value.DefaultCongestionThreshold = nil
-		case 10 - 1:
-			value.Mtu = nil
-		case 11 - 1:
-			value.Flags = nil
-		case 12 - 1:
-			value.Mask = nil
-		case 13 - 1:
-			value.Strategy = nil
-		case 14 - 1:
-			value.ExpirationPeriod = nil
-		case 15 - 1:
-			value.FacePersistency = nil
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -1790,10 +1750,11 @@ func (context *ControlResponseValParsingContext) Parse(reader enc.ParseReader, i
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 102:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.StatusCode = uint64(0)
 					{
@@ -1811,7 +1772,7 @@ func (context *ControlResponseValParsingContext) Parse(reader enc.ParseReader, i
 					}
 				}
 			case 103:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					{
 						var builder strings.Builder
@@ -1823,7 +1784,7 @@ func (context *ControlResponseValParsingContext) Parse(reader enc.ParseReader, i
 
 				}
 			case 104:
-				if progress+1 == 2 {
+				if true {
 					handled = true
 					value.Params, err = context.Params_context.Parse(reader.Delegate(int(l)), ignoreCritical)
 				}
@@ -1849,17 +1810,7 @@ func (context *ControlResponseValParsingContext) Parse(reader enc.ParseReader, i
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 3; progress++ {
-		switch progress {
-		case 0 - 1:
-			err = enc.ErrSkipRequired{Name: "StatusCode", TypeNum: 102}
-		case 1 - 1:
-			err = enc.ErrSkipRequired{Name: "StatusText", TypeNum: 103}
-		case 2 - 1:
-			value.Params = nil
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -2043,10 +1994,11 @@ func (context *ControlParametersParsingContext) Parse(reader enc.ParseReader, ig
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 104:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.Val, err = context.Val_context.Parse(reader.Delegate(int(l)), ignoreCritical)
 				}
@@ -2068,13 +2020,7 @@ func (context *ControlParametersParsingContext) Parse(reader enc.ParseReader, ig
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 1; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.Val = nil
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -2200,10 +2146,11 @@ func (context *ControlResponseParsingContext) Parse(reader enc.ParseReader, igno
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 101:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.Val, err = context.Val_context.Parse(reader.Delegate(int(l)), ignoreCritical)
 				}
@@ -2225,13 +2172,7 @@ func (context *ControlResponseParsingContext) Parse(reader enc.ParseReader, igno
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 1; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.Val = nil
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -2579,10 +2520,11 @@ func (context *FaceEventNotificationValueParsingContext) Parse(reader enc.ParseR
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 193:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.FaceEventKind = uint64(0)
 					{
@@ -2600,7 +2542,7 @@ func (context *FaceEventNotificationValueParsingContext) Parse(reader enc.ParseR
 					}
 				}
 			case 105:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					value.FaceId = uint64(0)
 					{
@@ -2618,7 +2560,7 @@ func (context *FaceEventNotificationValueParsingContext) Parse(reader enc.ParseR
 					}
 				}
 			case 114:
-				if progress+1 == 2 {
+				if true {
 					handled = true
 					{
 						var builder strings.Builder
@@ -2630,7 +2572,7 @@ func (context *FaceEventNotificationValueParsingContext) Parse(reader enc.ParseR
 
 				}
 			case 129:
-				if progress+1 == 3 {
+				if true {
 					handled = true
 					{
 						var builder strings.Builder
@@ -2642,7 +2584,7 @@ func (context *FaceEventNotificationValueParsingContext) Parse(reader enc.ParseR
 
 				}
 			case 132:
-				if progress+1 == 4 {
+				if true {
 					handled = true
 					value.FaceScope = uint64(0)
 					{
@@ -2660,7 +2602,7 @@ func (context *FaceEventNotificationValueParsingContext) Parse(reader enc.ParseR
 					}
 				}
 			case 133:
-				if progress+1 == 5 {
+				if true {
 					handled = true
 					value.FacePersistency = uint64(0)
 					{
@@ -2678,7 +2620,7 @@ func (context *FaceEventNotificationValueParsingContext) Parse(reader enc.ParseR
 					}
 				}
 			case 134:
-				if progress+1 == 6 {
+				if true {
 					handled = true
 					value.LinkType = uint64(0)
 					{
@@ -2696,7 +2638,7 @@ func (context *FaceEventNotificationValueParsingContext) Parse(reader enc.ParseR
 					}
 				}
 			case 108:
-				if progress+1 == 7 {
+				if true {
 					handled = true
 					value.Flags = uint64(0)
 					{
@@ -2745,27 +2687,7 @@ func (context *FaceEventNotificationValueParsingContext) Parse(reader enc.ParseR
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 8; progress++ {
-		switch progress {
-		case 0 - 1:
-			err = enc.ErrSkipRequired{Name: "FaceEventKind", TypeNum: 193}
-		case 1 - 1:
-			err = enc.ErrSkipRequired{Name: "FaceId", TypeNum: 105}
-		case 2 - 1:
-			err = enc.ErrSkipRequired{Name: "Uri", TypeNum: 114}
-		case 3 - 1:
-			err = enc.ErrSkipRequired{Name: "LocalUri", TypeNum: 129}
-		case 4 - 1:
-			err = enc.ErrSkipRequired{Name: "FaceScope", TypeNum: 132}
-		case 5 - 1:
-			err = enc.ErrSkipRequired{Name: "FacePersistency", TypeNum: 133}
-		case 6 - 1:
-			err = enc.ErrSkipRequired{Name: "LinkType", TypeNum: 134}
-		case 7 - 1:
-			err = enc.ErrSkipRequired{Name: "Flags", TypeNum: 108}
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -2891,10 +2813,11 @@ func (context *FaceEventNotificationParsingContext) Parse(reader enc.ParseReader
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 192:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.Val, err = context.Val_context.Parse(reader.Delegate(int(l)), ignoreCritical)
 				}
@@ -2916,13 +2839,7 @@ func (context *FaceEventNotificationParsingContext) Parse(reader enc.ParseReader
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 1; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.Val = nil
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -3865,10 +3782,11 @@ func (context *GeneralStatusParsingContext) Parse(reader enc.ParseReader, ignore
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 128:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					{
 						var builder strings.Builder
@@ -3880,7 +3798,7 @@ func (context *GeneralStatusParsingContext) Parse(reader enc.ParseReader, ignore
 
 				}
 			case 129:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					value.StartTimestamp = uint64(0)
 					{
@@ -3898,7 +3816,7 @@ func (context *GeneralStatusParsingContext) Parse(reader enc.ParseReader, ignore
 					}
 				}
 			case 130:
-				if progress+1 == 2 {
+				if true {
 					handled = true
 					value.CurrentTimestamp = uint64(0)
 					{
@@ -3916,7 +3834,7 @@ func (context *GeneralStatusParsingContext) Parse(reader enc.ParseReader, ignore
 					}
 				}
 			case 131:
-				if progress+1 == 3 {
+				if true {
 					handled = true
 					value.NNameTreeEntries = uint64(0)
 					{
@@ -3934,7 +3852,7 @@ func (context *GeneralStatusParsingContext) Parse(reader enc.ParseReader, ignore
 					}
 				}
 			case 132:
-				if progress+1 == 4 {
+				if true {
 					handled = true
 					value.NFibEntries = uint64(0)
 					{
@@ -3952,7 +3870,7 @@ func (context *GeneralStatusParsingContext) Parse(reader enc.ParseReader, ignore
 					}
 				}
 			case 133:
-				if progress+1 == 5 {
+				if true {
 					handled = true
 					value.NPitEntries = uint64(0)
 					{
@@ -3970,7 +3888,7 @@ func (context *GeneralStatusParsingContext) Parse(reader enc.ParseReader, ignore
 					}
 				}
 			case 134:
-				if progress+1 == 6 {
+				if true {
 					handled = true
 					value.NMeasurementsEntries = uint64(0)
 					{
@@ -3988,7 +3906,7 @@ func (context *GeneralStatusParsingContext) Parse(reader enc.ParseReader, ignore
 					}
 				}
 			case 135:
-				if progress+1 == 7 {
+				if true {
 					handled = true
 					value.NCsEntries = uint64(0)
 					{
@@ -4006,7 +3924,7 @@ func (context *GeneralStatusParsingContext) Parse(reader enc.ParseReader, ignore
 					}
 				}
 			case 144:
-				if progress+1 == 8 {
+				if true {
 					handled = true
 					value.NInInterests = uint64(0)
 					{
@@ -4024,7 +3942,7 @@ func (context *GeneralStatusParsingContext) Parse(reader enc.ParseReader, ignore
 					}
 				}
 			case 145:
-				if progress+1 == 9 {
+				if true {
 					handled = true
 					value.NInData = uint64(0)
 					{
@@ -4042,7 +3960,7 @@ func (context *GeneralStatusParsingContext) Parse(reader enc.ParseReader, ignore
 					}
 				}
 			case 151:
-				if progress+1 == 10 {
+				if true {
 					handled = true
 					value.NInNacks = uint64(0)
 					{
@@ -4060,7 +3978,7 @@ func (context *GeneralStatusParsingContext) Parse(reader enc.ParseReader, ignore
 					}
 				}
 			case 146:
-				if progress+1 == 11 {
+				if true {
 					handled = true
 					value.NOutInterests = uint64(0)
 					{
@@ -4078,7 +3996,7 @@ func (context *GeneralStatusParsingContext) Parse(reader enc.ParseReader, ignore
 					}
 				}
 			case 147:
-				if progress+1 == 12 {
+				if true {
 					handled = true
 					value.NOutData = uint64(0)
 					{
@@ -4096,7 +4014,7 @@ func (context *GeneralStatusParsingContext) Parse(reader enc.ParseReader, ignore
 					}
 				}
 			case 152:
-				if progress+1 == 13 {
+				if true {
 					handled = true
 					value.NOutNacks = uint64(0)
 					{
@@ -4114,7 +4032,7 @@ func (context *GeneralStatusParsingContext) Parse(reader enc.ParseReader, ignore
 					}
 				}
 			case 153:
-				if progress+1 == 14 {
+				if true {
 					handled = true
 					value.NSatisfiedInterests = uint64(0)
 					{
@@ -4132,7 +4050,7 @@ func (context *GeneralStatusParsingContext) Parse(reader enc.ParseReader, ignore
 					}
 				}
 			case 154:
-				if progress+1 == 15 {
+				if true {
 					handled = true
 					value.NUnsatisfiedInterests = uint64(0)
 					{
@@ -4150,7 +4068,7 @@ func (context *GeneralStatusParsingContext) Parse(reader enc.ParseReader, ignore
 					}
 				}
 			case 200:
-				if progress+1 == 16 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -4173,7 +4091,7 @@ func (context *GeneralStatusParsingContext) Parse(reader enc.ParseReader, ignore
 
 				}
 			case 201:
-				if progress+1 == 17 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -4196,7 +4114,7 @@ func (context *GeneralStatusParsingContext) Parse(reader enc.ParseReader, ignore
 
 				}
 			case 202:
-				if progress+1 == 18 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -4219,7 +4137,7 @@ func (context *GeneralStatusParsingContext) Parse(reader enc.ParseReader, ignore
 
 				}
 			case 203:
-				if progress+1 == 19 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -4242,7 +4160,7 @@ func (context *GeneralStatusParsingContext) Parse(reader enc.ParseReader, ignore
 
 				}
 			case 204:
-				if progress+1 == 20 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -4265,7 +4183,7 @@ func (context *GeneralStatusParsingContext) Parse(reader enc.ParseReader, ignore
 
 				}
 			case 205:
-				if progress+1 == 21 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -4288,7 +4206,7 @@ func (context *GeneralStatusParsingContext) Parse(reader enc.ParseReader, ignore
 
 				}
 			case 206:
-				if progress+1 == 22 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -4311,7 +4229,7 @@ func (context *GeneralStatusParsingContext) Parse(reader enc.ParseReader, ignore
 
 				}
 			case 207:
-				if progress+1 == 23 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -4334,7 +4252,7 @@ func (context *GeneralStatusParsingContext) Parse(reader enc.ParseReader, ignore
 
 				}
 			case 208:
-				if progress+1 == 24 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -4422,61 +4340,7 @@ func (context *GeneralStatusParsingContext) Parse(reader enc.ParseReader, ignore
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 25; progress++ {
-		switch progress {
-		case 0 - 1:
-			err = enc.ErrSkipRequired{Name: "NfdVersion", TypeNum: 128}
-		case 1 - 1:
-			err = enc.ErrSkipRequired{Name: "StartTimestamp", TypeNum: 129}
-		case 2 - 1:
-			err = enc.ErrSkipRequired{Name: "CurrentTimestamp", TypeNum: 130}
-		case 3 - 1:
-			err = enc.ErrSkipRequired{Name: "NNameTreeEntries", TypeNum: 131}
-		case 4 - 1:
-			err = enc.ErrSkipRequired{Name: "NFibEntries", TypeNum: 132}
-		case 5 - 1:
-			err = enc.ErrSkipRequired{Name: "NPitEntries", TypeNum: 133}
-		case 6 - 1:
-			err = enc.ErrSkipRequired{Name: "NMeasurementsEntries", TypeNum: 134}
-		case 7 - 1:
-			err = enc.ErrSkipRequired{Name: "NCsEntries", TypeNum: 135}
-		case 8 - 1:
-			err = enc.ErrSkipRequired{Name: "NInInterests", TypeNum: 144}
-		case 9 - 1:
-			err = enc.ErrSkipRequired{Name: "NInData", TypeNum: 145}
-		case 10 - 1:
-			err = enc.ErrSkipRequired{Name: "NInNacks", TypeNum: 151}
-		case 11 - 1:
-			err = enc.ErrSkipRequired{Name: "NOutInterests", TypeNum: 146}
-		case 12 - 1:
-			err = enc.ErrSkipRequired{Name: "NOutData", TypeNum: 147}
-		case 13 - 1:
-			err = enc.ErrSkipRequired{Name: "NOutNacks", TypeNum: 152}
-		case 14 - 1:
-			err = enc.ErrSkipRequired{Name: "NSatisfiedInterests", TypeNum: 153}
-		case 15 - 1:
-			err = enc.ErrSkipRequired{Name: "NUnsatisfiedInterests", TypeNum: 154}
-		case 16 - 1:
-			value.NFragmentationError = nil
-		case 17 - 1:
-			value.NOutOverMtu = nil
-		case 18 - 1:
-			value.NInLpInvalid = nil
-		case 19 - 1:
-			value.NReassemblyTimeouts = nil
-		case 20 - 1:
-			value.NInNetInvalid = nil
-		case 21 - 1:
-			value.NAcknowledged = nil
-		case 22 - 1:
-			value.NRetransmitted = nil
-		case 23 - 1:
-			value.NRetxExhausted = nil
-		case 24 - 1:
-			value.NConngestionMarked = nil
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -5203,10 +5067,11 @@ func (context *FaceStatusParsingContext) Parse(reader enc.ParseReader, ignoreCri
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 105:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.FaceId = uint64(0)
 					{
@@ -5224,7 +5089,7 @@ func (context *FaceStatusParsingContext) Parse(reader enc.ParseReader, ignoreCri
 					}
 				}
 			case 114:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					{
 						var builder strings.Builder
@@ -5236,7 +5101,7 @@ func (context *FaceStatusParsingContext) Parse(reader enc.ParseReader, ignoreCri
 
 				}
 			case 129:
-				if progress+1 == 2 {
+				if true {
 					handled = true
 					{
 						var builder strings.Builder
@@ -5248,7 +5113,7 @@ func (context *FaceStatusParsingContext) Parse(reader enc.ParseReader, ignoreCri
 
 				}
 			case 109:
-				if progress+1 == 3 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -5271,7 +5136,7 @@ func (context *FaceStatusParsingContext) Parse(reader enc.ParseReader, ignoreCri
 
 				}
 			case 132:
-				if progress+1 == 4 {
+				if true {
 					handled = true
 					value.FaceScope = uint64(0)
 					{
@@ -5289,7 +5154,7 @@ func (context *FaceStatusParsingContext) Parse(reader enc.ParseReader, ignoreCri
 					}
 				}
 			case 133:
-				if progress+1 == 5 {
+				if true {
 					handled = true
 					value.FacePersistency = uint64(0)
 					{
@@ -5307,7 +5172,7 @@ func (context *FaceStatusParsingContext) Parse(reader enc.ParseReader, ignoreCri
 					}
 				}
 			case 134:
-				if progress+1 == 6 {
+				if true {
 					handled = true
 					value.LinkType = uint64(0)
 					{
@@ -5325,7 +5190,7 @@ func (context *FaceStatusParsingContext) Parse(reader enc.ParseReader, ignoreCri
 					}
 				}
 			case 135:
-				if progress+1 == 7 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -5348,7 +5213,7 @@ func (context *FaceStatusParsingContext) Parse(reader enc.ParseReader, ignoreCri
 
 				}
 			case 136:
-				if progress+1 == 8 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -5371,7 +5236,7 @@ func (context *FaceStatusParsingContext) Parse(reader enc.ParseReader, ignoreCri
 
 				}
 			case 137:
-				if progress+1 == 9 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -5394,7 +5259,7 @@ func (context *FaceStatusParsingContext) Parse(reader enc.ParseReader, ignoreCri
 
 				}
 			case 144:
-				if progress+1 == 10 {
+				if true {
 					handled = true
 					value.NInInterests = uint64(0)
 					{
@@ -5412,7 +5277,7 @@ func (context *FaceStatusParsingContext) Parse(reader enc.ParseReader, ignoreCri
 					}
 				}
 			case 145:
-				if progress+1 == 11 {
+				if true {
 					handled = true
 					value.NInData = uint64(0)
 					{
@@ -5430,7 +5295,7 @@ func (context *FaceStatusParsingContext) Parse(reader enc.ParseReader, ignoreCri
 					}
 				}
 			case 151:
-				if progress+1 == 12 {
+				if true {
 					handled = true
 					value.NInNacks = uint64(0)
 					{
@@ -5448,7 +5313,7 @@ func (context *FaceStatusParsingContext) Parse(reader enc.ParseReader, ignoreCri
 					}
 				}
 			case 146:
-				if progress+1 == 13 {
+				if true {
 					handled = true
 					value.NOutInterests = uint64(0)
 					{
@@ -5466,7 +5331,7 @@ func (context *FaceStatusParsingContext) Parse(reader enc.ParseReader, ignoreCri
 					}
 				}
 			case 147:
-				if progress+1 == 14 {
+				if true {
 					handled = true
 					value.NOutData = uint64(0)
 					{
@@ -5484,7 +5349,7 @@ func (context *FaceStatusParsingContext) Parse(reader enc.ParseReader, ignoreCri
 					}
 				}
 			case 152:
-				if progress+1 == 15 {
+				if true {
 					handled = true
 					value.NOutNacks = uint64(0)
 					{
@@ -5502,7 +5367,7 @@ func (context *FaceStatusParsingContext) Parse(reader enc.ParseReader, ignoreCri
 					}
 				}
 			case 148:
-				if progress+1 == 16 {
+				if true {
 					handled = true
 					value.NInBytes = uint64(0)
 					{
@@ -5520,7 +5385,7 @@ func (context *FaceStatusParsingContext) Parse(reader enc.ParseReader, ignoreCri
 					}
 				}
 			case 149:
-				if progress+1 == 17 {
+				if true {
 					handled = true
 					value.NOutBytes = uint64(0)
 					{
@@ -5538,7 +5403,7 @@ func (context *FaceStatusParsingContext) Parse(reader enc.ParseReader, ignoreCri
 					}
 				}
 			case 108:
-				if progress+1 == 18 {
+				if true {
 					handled = true
 					value.Flags = uint64(0)
 					{
@@ -5609,49 +5474,7 @@ func (context *FaceStatusParsingContext) Parse(reader enc.ParseReader, ignoreCri
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 19; progress++ {
-		switch progress {
-		case 0 - 1:
-			err = enc.ErrSkipRequired{Name: "FaceId", TypeNum: 105}
-		case 1 - 1:
-			err = enc.ErrSkipRequired{Name: "Uri", TypeNum: 114}
-		case 2 - 1:
-			err = enc.ErrSkipRequired{Name: "LocalUri", TypeNum: 129}
-		case 3 - 1:
-			value.ExpirationPeriod = nil
-		case 4 - 1:
-			err = enc.ErrSkipRequired{Name: "FaceScope", TypeNum: 132}
-		case 5 - 1:
-			err = enc.ErrSkipRequired{Name: "FacePersistency", TypeNum: 133}
-		case 6 - 1:
-			err = enc.ErrSkipRequired{Name: "LinkType", TypeNum: 134}
-		case 7 - 1:
-			value.BaseCongestionMarkInterval = nil
-		case 8 - 1:
-			value.DefaultCongestionThreshold = nil
-		case 9 - 1:
-			value.Mtu = nil
-		case 10 - 1:
-			err = enc.ErrSkipRequired{Name: "NInInterests", TypeNum: 144}
-		case 11 - 1:
-			err = enc.ErrSkipRequired{Name: "NInData", TypeNum: 145}
-		case 12 - 1:
-			err = enc.ErrSkipRequired{Name: "NInNacks", TypeNum: 151}
-		case 13 - 1:
-			err = enc.ErrSkipRequired{Name: "NOutInterests", TypeNum: 146}
-		case 14 - 1:
-			err = enc.ErrSkipRequired{Name: "NOutData", TypeNum: 147}
-		case 15 - 1:
-			err = enc.ErrSkipRequired{Name: "NOutNacks", TypeNum: 152}
-		case 16 - 1:
-			err = enc.ErrSkipRequired{Name: "NInBytes", TypeNum: 148}
-		case 17 - 1:
-			err = enc.ErrSkipRequired{Name: "NOutBytes", TypeNum: 149}
-		case 18 - 1:
-			err = enc.ErrSkipRequired{Name: "Flags", TypeNum: 108}
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -5834,10 +5657,11 @@ func (context *FaceStatusMsgParsingContext) Parse(reader enc.ParseReader, ignore
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 128:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					if value.Vals == nil {
 						value.Vals = make([]*FaceStatus, 0)
@@ -5874,13 +5698,7 @@ func (context *FaceStatusMsgParsingContext) Parse(reader enc.ParseReader, ignore
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 1; progress++ {
-		switch progress {
-		case 0 - 1:
 
-		}
-	}
 	if err != nil {
 		return nil, err
 	}
@@ -6225,10 +6043,11 @@ func (context *FaceQueryFilterValueParsingContext) Parse(reader enc.ParseReader,
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 105:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -6251,7 +6070,7 @@ func (context *FaceQueryFilterValueParsingContext) Parse(reader enc.ParseReader,
 
 				}
 			case 131:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					{
 						var builder strings.Builder
@@ -6264,7 +6083,7 @@ func (context *FaceQueryFilterValueParsingContext) Parse(reader enc.ParseReader,
 
 				}
 			case 114:
-				if progress+1 == 2 {
+				if true {
 					handled = true
 					{
 						var builder strings.Builder
@@ -6277,7 +6096,7 @@ func (context *FaceQueryFilterValueParsingContext) Parse(reader enc.ParseReader,
 
 				}
 			case 129:
-				if progress+1 == 3 {
+				if true {
 					handled = true
 					{
 						var builder strings.Builder
@@ -6290,7 +6109,7 @@ func (context *FaceQueryFilterValueParsingContext) Parse(reader enc.ParseReader,
 
 				}
 			case 132:
-				if progress+1 == 4 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -6313,7 +6132,7 @@ func (context *FaceQueryFilterValueParsingContext) Parse(reader enc.ParseReader,
 
 				}
 			case 133:
-				if progress+1 == 5 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -6336,7 +6155,7 @@ func (context *FaceQueryFilterValueParsingContext) Parse(reader enc.ParseReader,
 
 				}
 			case 134:
-				if progress+1 == 6 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -6388,25 +6207,7 @@ func (context *FaceQueryFilterValueParsingContext) Parse(reader enc.ParseReader,
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 7; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.FaceId = nil
-		case 1 - 1:
-			value.UriScheme = nil
-		case 2 - 1:
-			value.Uri = nil
-		case 3 - 1:
-			value.LocalUri = nil
-		case 4 - 1:
-			value.FaceScope = nil
-		case 5 - 1:
-			value.FacePersistency = nil
-		case 6 - 1:
-			value.LinkType = nil
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -6532,10 +6333,11 @@ func (context *FaceQueryFilterParsingContext) Parse(reader enc.ParseReader, igno
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 150:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.Val, err = context.Val_context.Parse(reader.Delegate(int(l)), ignoreCritical)
 				}
@@ -6557,13 +6359,7 @@ func (context *FaceQueryFilterParsingContext) Parse(reader enc.ParseReader, igno
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 1; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.Val = nil
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -6812,10 +6608,11 @@ func (context *RouteParsingContext) Parse(reader enc.ParseReader, ignoreCritical
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 105:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.FaceId = uint64(0)
 					{
@@ -6833,7 +6630,7 @@ func (context *RouteParsingContext) Parse(reader enc.ParseReader, ignoreCritical
 					}
 				}
 			case 111:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					value.Origin = uint64(0)
 					{
@@ -6851,7 +6648,7 @@ func (context *RouteParsingContext) Parse(reader enc.ParseReader, ignoreCritical
 					}
 				}
 			case 106:
-				if progress+1 == 2 {
+				if true {
 					handled = true
 					value.Cost = uint64(0)
 					{
@@ -6869,7 +6666,7 @@ func (context *RouteParsingContext) Parse(reader enc.ParseReader, ignoreCritical
 					}
 				}
 			case 108:
-				if progress+1 == 3 {
+				if true {
 					handled = true
 					value.Flags = uint64(0)
 					{
@@ -6887,7 +6684,7 @@ func (context *RouteParsingContext) Parse(reader enc.ParseReader, ignoreCritical
 					}
 				}
 			case 109:
-				if progress+1 == 4 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -6935,21 +6732,7 @@ func (context *RouteParsingContext) Parse(reader enc.ParseReader, ignoreCritical
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 5; progress++ {
-		switch progress {
-		case 0 - 1:
-			err = enc.ErrSkipRequired{Name: "FaceId", TypeNum: 105}
-		case 1 - 1:
-			err = enc.ErrSkipRequired{Name: "Origin", TypeNum: 111}
-		case 2 - 1:
-			err = enc.ErrSkipRequired{Name: "Cost", TypeNum: 106}
-		case 3 - 1:
-			err = enc.ErrSkipRequired{Name: "Flags", TypeNum: 108}
-		case 4 - 1:
-			value.ExpirationPeriod = nil
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -7181,10 +6964,11 @@ func (context *RibEntryParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 7:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.Name = make(enc.Name, l/2+1)
 					startName := reader.Pos()
@@ -7209,7 +6993,7 @@ func (context *RibEntryParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 
 				}
 			case 129:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					if value.Routes == nil {
 						value.Routes = make([]*Route, 0)
@@ -7248,15 +7032,7 @@ func (context *RibEntryParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 2; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.Name = nil
-		case 1 - 1:
 
-		}
-	}
 	if err != nil {
 		return nil, err
 	}
@@ -7439,10 +7215,11 @@ func (context *RibStatusParsingContext) Parse(reader enc.ParseReader, ignoreCrit
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 128:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					if value.Entries == nil {
 						value.Entries = make([]*RibEntry, 0)
@@ -7479,13 +7256,7 @@ func (context *RibStatusParsingContext) Parse(reader enc.ParseReader, ignoreCrit
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 1; progress++ {
-		switch progress {
-		case 0 - 1:
 
-		}
-	}
 	if err != nil {
 		return nil, err
 	}
@@ -7631,10 +7402,11 @@ func (context *NextHopRecordParsingContext) Parse(reader enc.ParseReader, ignore
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 105:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.FaceId = uint64(0)
 					{
@@ -7652,7 +7424,7 @@ func (context *NextHopRecordParsingContext) Parse(reader enc.ParseReader, ignore
 					}
 				}
 			case 106:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					value.Cost = uint64(0)
 					{
@@ -7689,15 +7461,7 @@ func (context *NextHopRecordParsingContext) Parse(reader enc.ParseReader, ignore
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 2; progress++ {
-		switch progress {
-		case 0 - 1:
-			err = enc.ErrSkipRequired{Name: "FaceId", TypeNum: 105}
-		case 1 - 1:
-			err = enc.ErrSkipRequired{Name: "Cost", TypeNum: 106}
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -7929,10 +7693,11 @@ func (context *FibEntryParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 7:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.Name = make(enc.Name, l/2+1)
 					startName := reader.Pos()
@@ -7957,7 +7722,7 @@ func (context *FibEntryParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 
 				}
 			case 129:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					if value.NextHopRecords == nil {
 						value.NextHopRecords = make([]*NextHopRecord, 0)
@@ -7996,15 +7761,7 @@ func (context *FibEntryParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 2; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.Name = nil
-		case 1 - 1:
 
-		}
-	}
 	if err != nil {
 		return nil, err
 	}
@@ -8187,10 +7944,11 @@ func (context *FibStatusParsingContext) Parse(reader enc.ParseReader, ignoreCrit
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 128:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					if value.Entries == nil {
 						value.Entries = make([]*FibEntry, 0)
@@ -8227,13 +7985,7 @@ func (context *FibStatusParsingContext) Parse(reader enc.ParseReader, ignoreCrit
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 1; progress++ {
-		switch progress {
-		case 0 - 1:
 
-		}
-	}
 	if err != nil {
 		return nil, err
 	}
@@ -8408,10 +8160,11 @@ func (context *StrategyChoiceParsingContext) Parse(reader enc.ParseReader, ignor
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 7:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.Name = make(enc.Name, l/2+1)
 					startName := reader.Pos()
@@ -8436,7 +8189,7 @@ func (context *StrategyChoiceParsingContext) Parse(reader enc.ParseReader, ignor
 
 				}
 			case 107:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					value.Strategy, err = context.Strategy_context.Parse(reader.Delegate(int(l)), ignoreCritical)
 				}
@@ -8460,15 +8213,7 @@ func (context *StrategyChoiceParsingContext) Parse(reader enc.ParseReader, ignor
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 2; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.Name = nil
-		case 1 - 1:
-			value.Strategy = nil
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -8651,10 +8396,11 @@ func (context *StrategyChoiceMsgParsingContext) Parse(reader enc.ParseReader, ig
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 128:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					if value.StrategyChoices == nil {
 						value.StrategyChoices = make([]*StrategyChoice, 0)
@@ -8691,13 +8437,7 @@ func (context *StrategyChoiceMsgParsingContext) Parse(reader enc.ParseReader, ig
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 1; progress++ {
-		switch progress {
-		case 0 - 1:
 
-		}
-	}
 	if err != nil {
 		return nil, err
 	}
@@ -8942,10 +8682,11 @@ func (context *CsInfoParsingContext) Parse(reader enc.ParseReader, ignoreCritica
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 131:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.Capacity = uint64(0)
 					{
@@ -8963,7 +8704,7 @@ func (context *CsInfoParsingContext) Parse(reader enc.ParseReader, ignoreCritica
 					}
 				}
 			case 108:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					value.Flags = uint64(0)
 					{
@@ -8981,7 +8722,7 @@ func (context *CsInfoParsingContext) Parse(reader enc.ParseReader, ignoreCritica
 					}
 				}
 			case 135:
-				if progress+1 == 2 {
+				if true {
 					handled = true
 					value.NCsEntries = uint64(0)
 					{
@@ -8999,7 +8740,7 @@ func (context *CsInfoParsingContext) Parse(reader enc.ParseReader, ignoreCritica
 					}
 				}
 			case 129:
-				if progress+1 == 3 {
+				if true {
 					handled = true
 					value.NHits = uint64(0)
 					{
@@ -9017,7 +8758,7 @@ func (context *CsInfoParsingContext) Parse(reader enc.ParseReader, ignoreCritica
 					}
 				}
 			case 130:
-				if progress+1 == 4 {
+				if true {
 					handled = true
 					value.NMisses = uint64(0)
 					{
@@ -9060,21 +8801,7 @@ func (context *CsInfoParsingContext) Parse(reader enc.ParseReader, ignoreCritica
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 5; progress++ {
-		switch progress {
-		case 0 - 1:
-			err = enc.ErrSkipRequired{Name: "Capacity", TypeNum: 131}
-		case 1 - 1:
-			err = enc.ErrSkipRequired{Name: "Flags", TypeNum: 108}
-		case 2 - 1:
-			err = enc.ErrSkipRequired{Name: "NCsEntries", TypeNum: 135}
-		case 3 - 1:
-			err = enc.ErrSkipRequired{Name: "NHits", TypeNum: 129}
-		case 4 - 1:
-			err = enc.ErrSkipRequired{Name: "NMisses", TypeNum: 130}
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -9200,10 +8927,11 @@ func (context *CsInfoMsgParsingContext) Parse(reader enc.ParseReader, ignoreCrit
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 128:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.CsInfo, err = context.CsInfo_context.Parse(reader.Delegate(int(l)), ignoreCritical)
 				}
@@ -9225,13 +8953,7 @@ func (context *CsInfoMsgParsingContext) Parse(reader enc.ParseReader, ignoreCrit
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 1; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.CsInfo = nil
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ndn/ndn.go
+++ b/pkg/ndn/ndn.go
@@ -169,6 +169,8 @@ type InterestHandlerExtra struct {
 	Deadline time.Time
 	// PIT token
 	PitToken []byte
+	// Incoming face ID (if available)
+	IncomingFaceId *uint64
 }
 
 // SigChecker is a basic function to check the signature of a packet.

--- a/pkg/ndn/ndn.go
+++ b/pkg/ndn/ndn.go
@@ -157,10 +157,19 @@ type ExpressCallbackFunc func(result InterestResult, data Data, rawData enc.Wire
 // It should create a go routine to avoid blocking the main thread, if either
 // 1) Data is not ready to send; or
 // 2) Validation is required.
-type InterestHandler func(
-	interest Interest, rawInterest enc.Wire, sigCovered enc.Wire,
-	reply ReplyFunc, deadline time.Time,
-)
+type InterestHandler func(interest Interest, reply ReplyFunc, extra InterestHandlerExtra)
+
+// Extra information passed to the InterestHandler
+type InterestHandlerExtra struct {
+	// Raw Interest packet wire
+	RawInterest enc.Wire
+	// Signature covered part of the Interest
+	SigCovered enc.Wire
+	// Deadline of the Interest
+	Deadline time.Time
+	// PIT token
+	PitToken []byte
+}
 
 // SigChecker is a basic function to check the signature of a packet.
 // In NTSchema, policies&sub-trees are supposed to be used for validation;

--- a/pkg/ndn/spec_2022/definitions.go
+++ b/pkg/ndn/spec_2022/definitions.go
@@ -81,7 +81,7 @@ type CachePolicy struct {
 	CachePolicyType uint64 `tlv:"0x0335"`
 }
 
-//+tlv-model:nocopy,private
+// +tlv-model:nocopy,private
 type LpPacket struct {
 	//+field:fixedUint:uint64:optional
 	Sequence *uint64 `tlv:"0x51"`
@@ -114,7 +114,7 @@ type LpPacket struct {
 	Fragment enc.Wire `tlv:"0x50"`
 }
 
-//+tlv-model:nocopy,private
+// +tlv-model:nocopy,private,ordered
 type Interest struct {
 	//+field:procedureArgument:enc.Wire
 	sigCovered enc.PlaceHolder
@@ -152,7 +152,7 @@ type Interest struct {
 	digestCoverEnd enc.PlaceHolder
 }
 
-//+tlv-model:nocopy,private
+// +tlv-model:nocopy,private,ordered
 type Data struct {
 	//+field:procedureArgument:enc.Wire
 	sigCovered enc.PlaceHolder
@@ -171,7 +171,7 @@ type Data struct {
 	SignatureValue enc.Wire `tlv:"0x17"`
 }
 
-//+tlv-model:nocopy,private
+// +tlv-model:nocopy,private
 type Packet struct {
 	//+field:struct:Interest:nocopy
 	Interest *Interest `tlv:"0x05"`

--- a/pkg/ndn/spec_2022/zz_generated.go
+++ b/pkg/ndn/spec_2022/zz_generated.go
@@ -154,10 +154,11 @@ func (context *KeyLocatorParsingContext) Parse(reader enc.ParseReader, ignoreCri
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 7:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.Name = make(enc.Name, l/2+1)
 					startName := reader.Pos()
@@ -182,7 +183,7 @@ func (context *KeyLocatorParsingContext) Parse(reader enc.ParseReader, ignoreCri
 
 				}
 			case 29:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					value.KeyDigest = make([]byte, l)
 					_, err = io.ReadFull(reader, value.KeyDigest)
@@ -208,15 +209,7 @@ func (context *KeyLocatorParsingContext) Parse(reader enc.ParseReader, ignoreCri
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 2; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.Name = nil
-		case 1 - 1:
-			value.KeyDigest = nil
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -401,10 +394,11 @@ func (context *LinksParsingContext) Parse(reader enc.ParseReader, ignoreCritical
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 7:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					if value.Names == nil {
 						value.Names = make([]enc.Name, 0)
@@ -461,13 +455,7 @@ func (context *LinksParsingContext) Parse(reader enc.ParseReader, ignoreCritical
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 1; progress++ {
-		switch progress {
-		case 0 - 1:
 
-		}
-	}
 	if err != nil {
 		return nil, err
 	}
@@ -660,10 +648,11 @@ func (context *MetaInfoParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 24:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -686,7 +675,7 @@ func (context *MetaInfoParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 
 				}
 			case 25:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					{
 						timeInt := uint64(0)
@@ -710,7 +699,7 @@ func (context *MetaInfoParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 
 				}
 			case 26:
-				if progress+1 == 2 {
+				if true {
 					handled = true
 					value.FinalBlockID = make([]byte, l)
 					_, err = io.ReadFull(reader, value.FinalBlockID)
@@ -738,17 +727,7 @@ func (context *MetaInfoParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 3; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.ContentType = nil
-		case 1 - 1:
-			value.FreshnessPeriod = nil
-		case 2 - 1:
-			value.FinalBlockID = nil
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -900,10 +879,11 @@ func (context *ValidityPeriodParsingContext) Parse(reader enc.ParseReader, ignor
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 254:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					{
 						var builder strings.Builder
@@ -915,7 +895,7 @@ func (context *ValidityPeriodParsingContext) Parse(reader enc.ParseReader, ignor
 
 				}
 			case 255:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					{
 						var builder strings.Builder
@@ -946,15 +926,7 @@ func (context *ValidityPeriodParsingContext) Parse(reader enc.ParseReader, ignor
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 2; progress++ {
-		switch progress {
-		case 0 - 1:
-			err = enc.ErrSkipRequired{Name: "NotBefore", TypeNum: 254}
-		case 1 - 1:
-			err = enc.ErrSkipRequired{Name: "NotAfter", TypeNum: 255}
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -1106,10 +1078,11 @@ func (context *CertDescriptionEntryParsingContext) Parse(reader enc.ParseReader,
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 513:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					{
 						var builder strings.Builder
@@ -1121,7 +1094,7 @@ func (context *CertDescriptionEntryParsingContext) Parse(reader enc.ParseReader,
 
 				}
 			case 514:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					{
 						var builder strings.Builder
@@ -1152,15 +1125,7 @@ func (context *CertDescriptionEntryParsingContext) Parse(reader enc.ParseReader,
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 2; progress++ {
-		switch progress {
-		case 0 - 1:
-			err = enc.ErrSkipRequired{Name: "DescriptionKey", TypeNum: 513}
-		case 1 - 1:
-			err = enc.ErrSkipRequired{Name: "DescriptionValue", TypeNum: 514}
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -1344,10 +1309,11 @@ func (context *CertAdditionalDescriptionParsingContext) Parse(reader enc.ParseRe
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 512:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					if value.DescriptionEntries == nil {
 						value.DescriptionEntries = make([]*CertDescriptionEntry, 0)
@@ -1384,13 +1350,7 @@ func (context *CertAdditionalDescriptionParsingContext) Parse(reader enc.ParseRe
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 1; progress++ {
-		switch progress {
-		case 0 - 1:
 
-		}
-	}
 	if err != nil {
 		return nil, err
 	}
@@ -1764,10 +1724,11 @@ func (context *SignatureInfoParsingContext) Parse(reader enc.ParseReader, ignore
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 27:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.SignatureType = uint64(0)
 					{
@@ -1785,19 +1746,19 @@ func (context *SignatureInfoParsingContext) Parse(reader enc.ParseReader, ignore
 					}
 				}
 			case 28:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					value.KeyLocator, err = context.KeyLocator_context.Parse(reader.Delegate(int(l)), ignoreCritical)
 				}
 			case 38:
-				if progress+1 == 2 {
+				if true {
 					handled = true
 					value.SignatureNonce = make([]byte, l)
 					_, err = io.ReadFull(reader, value.SignatureNonce)
 
 				}
 			case 40:
-				if progress+1 == 3 {
+				if true {
 					handled = true
 					{
 						timeInt := uint64(0)
@@ -1821,7 +1782,7 @@ func (context *SignatureInfoParsingContext) Parse(reader enc.ParseReader, ignore
 
 				}
 			case 42:
-				if progress+1 == 4 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -1844,12 +1805,12 @@ func (context *SignatureInfoParsingContext) Parse(reader enc.ParseReader, ignore
 
 				}
 			case 253:
-				if progress+1 == 5 {
+				if true {
 					handled = true
 					value.ValidityPeriod, err = context.ValidityPeriod_context.Parse(reader.Delegate(int(l)), ignoreCritical)
 				}
 			case 258:
-				if progress+1 == 6 {
+				if true {
 					handled = true
 					value.AdditionalDescription, err = context.AdditionalDescription_context.Parse(reader.Delegate(int(l)), ignoreCritical)
 				}
@@ -1883,25 +1844,7 @@ func (context *SignatureInfoParsingContext) Parse(reader enc.ParseReader, ignore
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 7; progress++ {
-		switch progress {
-		case 0 - 1:
-			err = enc.ErrSkipRequired{Name: "SignatureType", TypeNum: 27}
-		case 1 - 1:
-			value.KeyLocator = nil
-		case 2 - 1:
-			value.SignatureNonce = nil
-		case 3 - 1:
-			value.SignatureTime = nil
-		case 4 - 1:
-			value.SignatureSeqNum = nil
-		case 5 - 1:
-			value.ValidityPeriod = nil
-		case 6 - 1:
-			value.AdditionalDescription = nil
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -2015,10 +1958,11 @@ func (context *NetworkNackParsingContext) Parse(reader enc.ParseReader, ignoreCr
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 801:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.Reason = uint64(0)
 					{
@@ -2053,13 +1997,7 @@ func (context *NetworkNackParsingContext) Parse(reader enc.ParseReader, ignoreCr
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 1; progress++ {
-		switch progress {
-		case 0 - 1:
-			err = enc.ErrSkipRequired{Name: "Reason", TypeNum: 801}
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -2173,10 +2111,11 @@ func (context *CachePolicyParsingContext) Parse(reader enc.ParseReader, ignoreCr
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 821:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.CachePolicyType = uint64(0)
 					{
@@ -2211,13 +2150,7 @@ func (context *CachePolicyParsingContext) Parse(reader enc.ParseReader, ignoreCr
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 1; progress++ {
-		switch progress {
-		case 0 - 1:
-			err = enc.ErrSkipRequired{Name: "CachePolicyType", TypeNum: 821}
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -3002,10 +2935,11 @@ func (context *LpPacketParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 81:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -3028,7 +2962,7 @@ func (context *LpPacketParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 
 				}
 			case 82:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -3051,7 +2985,7 @@ func (context *LpPacketParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 
 				}
 			case 83:
-				if progress+1 == 2 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -3074,19 +3008,19 @@ func (context *LpPacketParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 
 				}
 			case 98:
-				if progress+1 == 3 {
+				if true {
 					handled = true
 					value.PitToken = make([]byte, l)
 					_, err = io.ReadFull(reader, value.PitToken)
 
 				}
 			case 800:
-				if progress+1 == 4 {
+				if true {
 					handled = true
 					value.Nack, err = context.Nack_context.Parse(reader.Delegate(int(l)), ignoreCritical)
 				}
 			case 812:
-				if progress+1 == 5 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -3109,7 +3043,7 @@ func (context *LpPacketParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 
 				}
 			case 816:
-				if progress+1 == 6 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -3132,12 +3066,12 @@ func (context *LpPacketParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 
 				}
 			case 820:
-				if progress+1 == 7 {
+				if true {
 					handled = true
 					value.CachePolicy, err = context.CachePolicy_context.Parse(reader.Delegate(int(l)), ignoreCritical)
 				}
 			case 832:
-				if progress+1 == 8 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -3160,7 +3094,7 @@ func (context *LpPacketParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 
 				}
 			case 836:
-				if progress+1 == 9 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -3183,7 +3117,7 @@ func (context *LpPacketParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 
 				}
 			case 840:
-				if progress+1 == 10 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -3206,18 +3140,18 @@ func (context *LpPacketParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 
 				}
 			case 844:
-				if progress+1 == 11 {
+				if true {
 					handled = true
 					value.NonDiscovery = true
 				}
 			case 848:
-				if progress+1 == 12 {
+				if true {
 					handled = true
 					value.PrefixAnnouncement, err = reader.ReadWire(int(l))
 
 				}
 			case 80:
-				if progress+1 == 13 {
+				if true {
 					handled = true
 					value.Fragment, err = reader.ReadWire(int(l))
 
@@ -3266,39 +3200,7 @@ func (context *LpPacketParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 14; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.Sequence = nil
-		case 1 - 1:
-			value.FragIndex = nil
-		case 2 - 1:
-			value.FragCount = nil
-		case 3 - 1:
-			value.PitToken = nil
-		case 4 - 1:
-			value.Nack = nil
-		case 5 - 1:
-			value.IncomingFaceId = nil
-		case 6 - 1:
-			value.NextHopFaceId = nil
-		case 7 - 1:
-			value.CachePolicy = nil
-		case 8 - 1:
-			value.CongestionMark = nil
-		case 9 - 1:
-			value.Ack = nil
-		case 10 - 1:
-			value.TxSequence = nil
-		case 11 - 1:
-			value.NonDiscovery = false
-		case 12 - 1:
-			value.PrefixAnnouncement = nil
-		case 13 - 1:
-			value.Fragment = nil
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -3930,7 +3832,7 @@ func (context *InterestParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		for handled := false; !handled && progress < 15; progress++ {
 			switch typ {
 			case 7:
 				if progress+1 == 2 {
@@ -4153,6 +4055,7 @@ func (context *InterestParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 
 		}
 	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -4605,7 +4508,7 @@ func (context *DataParsingContext) Parse(reader enc.ParseReader, ignoreCritical 
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		for handled := false; !handled && progress < 7; progress++ {
 			switch typ {
 			case 7:
 				if progress+1 == 2 {
@@ -4707,6 +4610,7 @@ func (context *DataParsingContext) Parse(reader enc.ParseReader, ignoreCritical 
 			value.SignatureValue = nil
 		}
 	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -5077,20 +4981,21 @@ func (context *PacketParsingContext) Parse(reader enc.ParseReader, ignoreCritica
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 5:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.Interest, err = context.Interest_context.Parse(reader.Delegate(int(l)), ignoreCritical)
 				}
 			case 6:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					value.Data, err = context.Data_context.Parse(reader.Delegate(int(l)), ignoreCritical)
 				}
 			case 100:
-				if progress+1 == 2 {
+				if true {
 					handled = true
 					value.LpPacket, err = context.LpPacket_context.Parse(reader.Delegate(int(l)), ignoreCritical)
 				}
@@ -5116,17 +5021,7 @@ func (context *PacketParsingContext) Parse(reader enc.ParseReader, ignoreCritica
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 3; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.Interest = nil
-		case 1 - 1:
-			value.Data = nil
-		case 2 - 1:
-			value.LpPacket = nil
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/schema/base_node.go
+++ b/pkg/schema/base_node.go
@@ -3,7 +3,6 @@ package schema
 import (
 	"errors"
 	"reflect"
-	"time"
 
 	enc "github.com/zjkmxy/go-ndn/pkg/encoding"
 	"github.com/zjkmxy/go-ndn/pkg/log"
@@ -196,13 +195,15 @@ func (n *Node) ConstructName(matching enc.Matching, ret enc.Name) error {
 // OnInterest is the function called when an Interest comes.
 // A base node shouldn't receive any Interest, so drops it.
 func (n *Node) OnInterest(
-	interest ndn.Interest, rawInterest enc.Wire, sigCovered enc.Wire,
-	reply ndn.ReplyFunc, deadline time.Time, matching enc.Matching,
+	interest ndn.Interest,
+	reply ndn.ReplyFunc,
+	extra ndn.InterestHandlerExtra,
+	matching enc.Matching,
 ) {
 	if n.impl == nil {
 		n.log.WithField("name", interest.Name().String()).Warn("Unexpected Interest. Drop.")
 	} else {
-		n.impl.OnInterest(interest, rawInterest, sigCovered, reply, deadline, matching)
+		n.impl.OnInterest(interest, reply, extra, matching)
 	}
 }
 
@@ -350,8 +351,8 @@ func (n *BaseNodeImpl) NodeImplTrait() NodeImpl {
 
 // OnInterest is the callback function when there is an incoming Interest.
 func (n *BaseNodeImpl) OnInterest(
-	interest ndn.Interest, rawInterest enc.Wire, sigCovered enc.Wire,
-	reply ndn.ReplyFunc, deadline time.Time, matching enc.Matching,
+	interest ndn.Interest, reply ndn.ReplyFunc,
+	extra ndn.InterestHandlerExtra, matching enc.Matching,
 ) {
 	n.Node.Log().WithField("name", interest.Name().String()).Warn("Unexpected Interest. Drop.")
 }

--- a/pkg/schema/demosec/zz_generated.go
+++ b/pkg/schema/demosec/zz_generated.go
@@ -315,24 +315,25 @@ func (context *EncryptedContentParsingContext) Parse(reader enc.ParseReader, ign
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 130:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.KeyId = make([]byte, l)
 					_, err = io.ReadFull(reader, value.KeyId)
 
 				}
 			case 132:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					value.Iv = make([]byte, l)
 					_, err = io.ReadFull(reader, value.Iv)
 
 				}
 			case 134:
-				if progress+1 == 2 {
+				if true {
 					handled = true
 					value.ContentLength = uint64(0)
 					{
@@ -350,7 +351,7 @@ func (context *EncryptedContentParsingContext) Parse(reader enc.ParseReader, ign
 					}
 				}
 			case 136:
-				if progress+1 == 3 {
+				if true {
 					handled = true
 					value.CipherText, err = reader.ReadWire(int(l))
 
@@ -379,19 +380,7 @@ func (context *EncryptedContentParsingContext) Parse(reader enc.ParseReader, ign
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 4; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.KeyId = nil
-		case 1 - 1:
-			value.Iv = nil
-		case 2 - 1:
-			err = enc.ErrSkipRequired{Name: "ContentLength", TypeNum: 134}
-		case 3 - 1:
-			value.CipherText = nil
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/schema/expressing_point.go
+++ b/pkg/schema/expressing_point.go
@@ -76,8 +76,8 @@ func (n *ExpressPoint) SearchCache(event *Event) enc.Wire {
 }
 
 func (n *ExpressPoint) OnInterest(
-	interest ndn.Interest, rawInterest enc.Wire, sigCovered enc.Wire,
-	reply ndn.ReplyFunc, deadline time.Time, matching enc.Matching,
+	interest ndn.Interest, reply ndn.ReplyFunc,
+	extra ndn.InterestHandlerExtra, matching enc.Matching,
 ) {
 	node := n.Node
 	event := &Event{
@@ -87,12 +87,12 @@ func (n *ExpressPoint) OnInterest(
 			Matching: matching,
 			Name:     interest.Name(),
 		},
-		RawPacket:  rawInterest,
-		SigCovered: sigCovered,
+		RawPacket:  extra.RawInterest,
+		SigCovered: extra.SigCovered,
 		Interest:   interest,
 		Signature:  interest.Signature(),
 		Reply:      reply,
-		Deadline:   &deadline,
+		Deadline:   &extra.Deadline,
 		Content:    interest.AppParam(),
 	}
 	logger := event.Target.Logger("ExpressPoint")

--- a/pkg/schema/interface.go
+++ b/pkg/schema/interface.go
@@ -49,8 +49,8 @@ type NodeImpl interface {
 	CastTo(ptr any) any
 
 	// OnInterest is the callback function when there is an incoming Interest.
-	OnInterest(interest ndn.Interest, rawInterest enc.Wire, sigCovered enc.Wire,
-		reply ndn.ReplyFunc, deadline time.Time, matching enc.Matching)
+	OnInterest(interest ndn.Interest, reply ndn.ReplyFunc,
+		extra ndn.InterestHandlerExtra, matching enc.Matching)
 
 	// OnAttach is called when the node is attached to an engine
 	OnAttach() error

--- a/pkg/schema/rdr/zz_generated.go
+++ b/pkg/schema/rdr/zz_generated.go
@@ -138,10 +138,11 @@ func (context *ManifestDigestParsingContext) Parse(reader enc.ParseReader, ignor
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 204:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.SegNo = uint64(0)
 					{
@@ -159,7 +160,7 @@ func (context *ManifestDigestParsingContext) Parse(reader enc.ParseReader, ignor
 					}
 				}
 			case 206:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					value.Digest = make([]byte, l)
 					_, err = io.ReadFull(reader, value.Digest)
@@ -185,15 +186,7 @@ func (context *ManifestDigestParsingContext) Parse(reader enc.ParseReader, ignor
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 2; progress++ {
-		switch progress {
-		case 0 - 1:
-			err = enc.ErrSkipRequired{Name: "SegNo", TypeNum: 204}
-		case 1 - 1:
-			value.Digest = nil
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -376,10 +369,11 @@ func (context *ManifestDataParsingContext) Parse(reader enc.ParseReader, ignoreC
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 202:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					if value.Entries == nil {
 						value.Entries = make([]*ManifestDigest, 0)
@@ -416,13 +410,7 @@ func (context *ManifestDataParsingContext) Parse(reader enc.ParseReader, ignoreC
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 1; progress++ {
-		switch progress {
-		case 0 - 1:
 
-		}
-	}
 	if err != nil {
 		return nil, err
 	}
@@ -895,10 +883,11 @@ func (context *MetaDataParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 7:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.Name = make(enc.Name, l/2+1)
 					startName := reader.Pos()
@@ -923,14 +912,14 @@ func (context *MetaDataParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 
 				}
 			case 26:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					value.FinalBlockID = make([]byte, l)
 					_, err = io.ReadFull(reader, value.FinalBlockID)
 
 				}
 			case 62720:
-				if progress+1 == 2 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -953,7 +942,7 @@ func (context *MetaDataParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 
 				}
 			case 62722:
-				if progress+1 == 3 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -976,7 +965,7 @@ func (context *MetaDataParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 
 				}
 			case 62724:
-				if progress+1 == 4 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -999,7 +988,7 @@ func (context *MetaDataParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 
 				}
 			case 62726:
-				if progress+1 == 5 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -1022,7 +1011,7 @@ func (context *MetaDataParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 
 				}
 			case 62728:
-				if progress+1 == 6 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -1045,7 +1034,7 @@ func (context *MetaDataParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 
 				}
 			case 62730:
-				if progress+1 == 7 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -1068,7 +1057,7 @@ func (context *MetaDataParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 
 				}
 			case 62732:
-				if progress+1 == 8 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -1091,7 +1080,7 @@ func (context *MetaDataParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 
 				}
 			case 62734:
-				if progress+1 == 9 {
+				if true {
 					handled = true
 					{
 						var builder strings.Builder
@@ -1139,31 +1128,7 @@ func (context *MetaDataParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 10; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.Name = nil
-		case 1 - 1:
-			value.FinalBlockID = nil
-		case 2 - 1:
-			value.SegmentSize = nil
-		case 3 - 1:
-			value.Size = nil
-		case 4 - 1:
-			value.Mode = nil
-		case 5 - 1:
-			value.Atime = nil
-		case 6 - 1:
-			value.Btime = nil
-		case 7 - 1:
-			value.Ctime = nil
-		case 8 - 1:
-			value.Mtime = nil
-		case 9 - 1:
-			value.ObjectType = nil
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/schema/svs/zz_generated.go
+++ b/pkg/schema/svs/zz_generated.go
@@ -137,17 +137,18 @@ func (context *StateVecEntryParsingContext) Parse(reader enc.ParseReader, ignore
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 7:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.NodeId = make([]byte, l)
 					_, err = io.ReadFull(reader, value.NodeId)
 
 				}
 			case 204:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					value.SeqNo = uint64(0)
 					{
@@ -184,15 +185,7 @@ func (context *StateVecEntryParsingContext) Parse(reader enc.ParseReader, ignore
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 2; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.NodeId = nil
-		case 1 - 1:
-			err = enc.ErrSkipRequired{Name: "SeqNo", TypeNum: 204}
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -375,10 +368,11 @@ func (context *StateVecParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 202:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					if value.Entries == nil {
 						value.Entries = make([]*StateVecEntry, 0)
@@ -415,13 +409,7 @@ func (context *StateVecParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 1; progress++ {
-		switch progress {
-		case 0 - 1:
 
-		}
-	}
 	if err != nil {
 		return nil, err
 	}
@@ -547,10 +535,11 @@ func (context *StateVecAppParamParsingContext) Parse(reader enc.ParseReader, ign
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 201:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.Entries, err = context.Entries_context.Parse(reader.Delegate(int(l)), ignoreCritical)
 				}
@@ -572,13 +561,7 @@ func (context *StateVecAppParamParsingContext) Parse(reader enc.ParseReader, ign
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 1; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.Entries = nil
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/schema/tree.go
+++ b/pkg/schema/tree.go
@@ -3,7 +3,6 @@ package schema
 import (
 	"errors"
 	"sync"
-	"time"
 
 	enc "github.com/zjkmxy/go-ndn/pkg/encoding"
 	"github.com/zjkmxy/go-ndn/pkg/log"
@@ -74,8 +73,9 @@ func (t *Tree) Match(name enc.Name) *MatchedNode {
 
 // intHandler is the callback called by the engine that handles an incoming Interest.
 func (t *Tree) intHandler(
-	interest ndn.Interest, rawInterest enc.Wire, sigCovered enc.Wire,
-	reply ndn.ReplyFunc, deadline time.Time,
+	interest ndn.Interest,
+	reply ndn.ReplyFunc,
+	extra ndn.InterestHandlerExtra,
 ) {
 	t.lock.RLock()
 	defer t.lock.RUnlock()
@@ -86,7 +86,7 @@ func (t *Tree) intHandler(
 		log.WithField("module", "schema").WithField("name", interest.Name().String()).Warn("Unexpected Interest. Drop.")
 		return
 	}
-	mNode.Node.OnInterest(interest, rawInterest, sigCovered, reply, deadline, mNode.Matching)
+	mNode.Node.OnInterest(interest, reply, extra, mNode.Matching)
 }
 
 // At the path return the node. Path does not include the attached prefix.

--- a/pkg/schema_old/base_node.go
+++ b/pkg/schema_old/base_node.go
@@ -1,8 +1,7 @@
-package schema
+package schema_old
 
 import (
 	"errors"
-	"time"
 
 	enc "github.com/zjkmxy/go-ndn/pkg/encoding"
 	"github.com/zjkmxy/go-ndn/pkg/log"
@@ -136,8 +135,8 @@ func (n *BaseNode) ConstructName(matching enc.Matching, ret enc.Name) error {
 // OnInterest is the function called when an Interest comes.
 // A base node shouldn't receive any Interest, so drops it.
 func (n *BaseNode) OnInterest(
-	interest ndn.Interest, rawInterest enc.Wire, sigCovered enc.Wire,
-	reply ndn.ReplyFunc, deadline time.Time, matching enc.Matching,
+	interest ndn.Interest, reply ndn.ReplyFunc,
+	extra ndn.InterestHandlerExtra, matching enc.Matching,
 ) {
 	n.Log.WithField("name", interest.Name().String()).Warn("Unexpected Interest. Drop.")
 }

--- a/pkg/schema_old/certdemo/zz_generated.go
+++ b/pkg/schema_old/certdemo/zz_generated.go
@@ -325,10 +325,11 @@ func (context *CaProfileParsingContext) Parse(reader enc.ParseReader, ignoreCrit
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 129:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.CaPrefix = make(enc.Name, l/2+1)
 					startName := reader.Pos()
@@ -353,7 +354,7 @@ func (context *CaProfileParsingContext) Parse(reader enc.ParseReader, ignoreCrit
 
 				}
 			case 131:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					{
 						var builder strings.Builder
@@ -365,7 +366,7 @@ func (context *CaProfileParsingContext) Parse(reader enc.ParseReader, ignoreCrit
 
 				}
 			case 133:
-				if progress+1 == 2 {
+				if true {
 					handled = true
 					if value.ParamKey == nil {
 						value.ParamKey = make([]string, 0)
@@ -392,7 +393,7 @@ func (context *CaProfileParsingContext) Parse(reader enc.ParseReader, ignoreCrit
 
 				}
 			case 139:
-				if progress+1 == 3 {
+				if true {
 					handled = true
 					value.MaxValidPeriod = uint64(0)
 					{
@@ -410,7 +411,7 @@ func (context *CaProfileParsingContext) Parse(reader enc.ParseReader, ignoreCrit
 					}
 				}
 			case 137:
-				if progress+1 == 4 {
+				if true {
 					handled = true
 					value.CaCert, err = reader.ReadWire(int(l))
 
@@ -441,21 +442,7 @@ func (context *CaProfileParsingContext) Parse(reader enc.ParseReader, ignoreCrit
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 5; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.CaPrefix = nil
-		case 1 - 1:
-			err = enc.ErrSkipRequired{Name: "CaInfo", TypeNum: 131}
-		case 2 - 1:
 
-		case 3 - 1:
-			err = enc.ErrSkipRequired{Name: "MaxValidPeriod", TypeNum: 139}
-		case 4 - 1:
-			value.CaCert = nil
-		}
-	}
 	if err != nil {
 		return nil, err
 	}
@@ -609,10 +596,11 @@ func (context *ParamParsingContext) Parse(reader enc.ParseReader, ignoreCritical
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 133:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					{
 						var builder strings.Builder
@@ -624,7 +612,7 @@ func (context *ParamParsingContext) Parse(reader enc.ParseReader, ignoreCritical
 
 				}
 			case 135:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					value.ParamValue = make([]byte, l)
 					_, err = io.ReadFull(reader, value.ParamValue)
@@ -650,15 +638,7 @@ func (context *ParamParsingContext) Parse(reader enc.ParseReader, ignoreCritical
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 2; progress++ {
-		switch progress {
-		case 0 - 1:
-			err = enc.ErrSkipRequired{Name: "ParamKey", TypeNum: 133}
-		case 1 - 1:
-			value.ParamValue = nil
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -841,10 +821,11 @@ func (context *ProbeIntParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 193:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					if value.Params == nil {
 						value.Params = make([]*Param, 0)
@@ -881,13 +862,7 @@ func (context *ProbeIntParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 1; progress++ {
-		switch progress {
-		case 0 - 1:
 
-		}
-	}
 	if err != nil {
 		return nil, err
 	}
@@ -1052,10 +1027,11 @@ func (context *ProbeResParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 141:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.Response = make(enc.Name, l/2+1)
 					startName := reader.Pos()
@@ -1099,15 +1075,7 @@ func (context *ProbeResParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 2; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.Response = nil
-		case 1 - 1:
-			value.MaxSuffixLength = nil
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -1265,17 +1233,18 @@ func (context *CmdNewIntParsingContext) Parse(reader enc.ParseReader, ignoreCrit
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 145:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.EcdhPub = make([]byte, l)
 					_, err = io.ReadFull(reader, value.EcdhPub)
 
 				}
 			case 147:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					value.CertReq = make([]byte, l)
 					_, err = io.ReadFull(reader, value.CertReq)
@@ -1301,15 +1270,7 @@ func (context *CmdNewIntParsingContext) Parse(reader enc.ParseReader, ignoreCrit
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 2; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.EcdhPub = nil
-		case 1 - 1:
-			value.CertReq = nil
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -1599,31 +1560,32 @@ func (context *CmdNewDataParsingContext) Parse(reader enc.ParseReader, ignoreCri
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 145:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.EcdhPub = make([]byte, l)
 					_, err = io.ReadFull(reader, value.EcdhPub)
 
 				}
 			case 149:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					value.Salt = make([]byte, l)
 					_, err = io.ReadFull(reader, value.Salt)
 
 				}
 			case 151:
-				if progress+1 == 2 {
+				if true {
 					handled = true
 					value.ReqId = make([]byte, l)
 					_, err = io.ReadFull(reader, value.ReqId)
 
 				}
 			case 153:
-				if progress+1 == 3 {
+				if true {
 					handled = true
 					if value.Challenge == nil {
 						value.Challenge = make([]string, 0)
@@ -1673,19 +1635,7 @@ func (context *CmdNewDataParsingContext) Parse(reader enc.ParseReader, ignoreCri
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 4; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.EcdhPub = nil
-		case 1 - 1:
-			value.Salt = nil
-		case 2 - 1:
-			value.ReqId = nil
-		case 3 - 1:
 
-		}
-	}
 	if err != nil {
 		return nil, err
 	}
@@ -1882,24 +1832,25 @@ func (context *CipherMsgParsingContext) Parse(reader enc.ParseReader, ignoreCrit
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 157:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.InitVec = make([]byte, l)
 					_, err = io.ReadFull(reader, value.InitVec)
 
 				}
 			case 175:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					value.AuthNTag = make([]byte, l)
 					_, err = io.ReadFull(reader, value.AuthNTag)
 
 				}
 			case 159:
-				if progress+1 == 2 {
+				if true {
 					handled = true
 					value.Payload = make([]byte, l)
 					_, err = io.ReadFull(reader, value.Payload)
@@ -1927,17 +1878,7 @@ func (context *CipherMsgParsingContext) Parse(reader enc.ParseReader, ignoreCrit
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 3; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.InitVec = nil
-		case 1 - 1:
-			value.AuthNTag = nil
-		case 2 - 1:
-			value.Payload = nil
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -2157,10 +2098,11 @@ func (context *ChallengeIntPlainParsingContext) Parse(reader enc.ParseReader, ig
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 161:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					{
 						var builder strings.Builder
@@ -2172,7 +2114,7 @@ func (context *ChallengeIntPlainParsingContext) Parse(reader enc.ParseReader, ig
 
 				}
 			case 193:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					if value.Params == nil {
 						value.Params = make([]*Param, 0)
@@ -2211,15 +2153,7 @@ func (context *ChallengeIntPlainParsingContext) Parse(reader enc.ParseReader, ig
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 2; progress++ {
-		switch progress {
-		case 0 - 1:
-			err = enc.ErrSkipRequired{Name: "SelectedChal", TypeNum: 161}
-		case 1 - 1:
 
-		}
-	}
 	if err != nil {
 		return nil, err
 	}
@@ -2644,10 +2578,11 @@ func (context *ChallengeDataPlainParsingContext) Parse(reader enc.ParseReader, i
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 155:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.Status = uint64(0)
 					{
@@ -2665,7 +2600,7 @@ func (context *ChallengeDataPlainParsingContext) Parse(reader enc.ParseReader, i
 					}
 				}
 			case 163:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -2688,7 +2623,7 @@ func (context *ChallengeDataPlainParsingContext) Parse(reader enc.ParseReader, i
 
 				}
 			case 165:
-				if progress+1 == 2 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -2711,7 +2646,7 @@ func (context *ChallengeDataPlainParsingContext) Parse(reader enc.ParseReader, i
 
 				}
 			case 167:
-				if progress+1 == 3 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -2734,7 +2669,7 @@ func (context *ChallengeDataPlainParsingContext) Parse(reader enc.ParseReader, i
 
 				}
 			case 169:
-				if progress+1 == 4 {
+				if true {
 					handled = true
 					value.CertName = make(enc.Name, l/2+1)
 					startName := reader.Pos()
@@ -2759,7 +2694,7 @@ func (context *ChallengeDataPlainParsingContext) Parse(reader enc.ParseReader, i
 
 				}
 			case 30:
-				if progress+1 == 5 {
+				if true {
 					handled = true
 					value.ForwardingHint = make(enc.Name, l/2+1)
 					startName := reader.Pos()
@@ -2784,7 +2719,7 @@ func (context *ChallengeDataPlainParsingContext) Parse(reader enc.ParseReader, i
 
 				}
 			case 193:
-				if progress+1 == 6 {
+				if true {
 					handled = true
 					if value.Params == nil {
 						value.Params = make([]*Param, 0)
@@ -2833,25 +2768,7 @@ func (context *ChallengeDataPlainParsingContext) Parse(reader enc.ParseReader, i
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 7; progress++ {
-		switch progress {
-		case 0 - 1:
-			err = enc.ErrSkipRequired{Name: "Status", TypeNum: 155}
-		case 1 - 1:
-			value.ChalStatus = nil
-		case 2 - 1:
-			value.RemainTries = nil
-		case 3 - 1:
-			value.RemainTime = nil
-		case 4 - 1:
-			value.CertName = nil
-		case 5 - 1:
-			value.ForwardingHint = nil
-		case 6 - 1:
 
-		}
-	}
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/schema_old/demo/zz_generated.go
+++ b/pkg/schema_old/demo/zz_generated.go
@@ -137,17 +137,18 @@ func (context *StateVecEntryParsingContext) Parse(reader enc.ParseReader, ignore
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 7:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.NodeId = make([]byte, l)
 					_, err = io.ReadFull(reader, value.NodeId)
 
 				}
 			case 204:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					value.SeqNo = uint64(0)
 					{
@@ -184,15 +185,7 @@ func (context *StateVecEntryParsingContext) Parse(reader enc.ParseReader, ignore
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 2; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.NodeId = nil
-		case 1 - 1:
-			err = enc.ErrSkipRequired{Name: "SeqNo", TypeNum: 204}
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -375,10 +368,11 @@ func (context *StateVecParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 202:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					if value.Entries == nil {
 						value.Entries = make([]*StateVecEntry, 0)
@@ -415,13 +409,7 @@ func (context *StateVecParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 1; progress++ {
-		switch progress {
-		case 0 - 1:
 
-		}
-	}
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/schema_old/event.go
+++ b/pkg/schema_old/event.go
@@ -1,4 +1,4 @@
-package schema
+package schema_old
 
 // Event is a chain of callback functions for an event.
 // The execution order is supposed to be the addition order.

--- a/pkg/schema_old/expressing_point.go
+++ b/pkg/schema_old/expressing_point.go
@@ -1,4 +1,4 @@
-package schema
+package schema_old
 
 import (
 	"time"
@@ -45,14 +45,13 @@ func (n *ExpressPoint) SearchCache(
 
 // OnInterest is the function called when an Interest comes.
 func (n *ExpressPoint) OnInterest(
-	interest ndn.Interest, rawInterest enc.Wire, sigCovered enc.Wire,
-	reply ndn.ReplyFunc, deadline time.Time, matching enc.Matching,
+	interest ndn.Interest, reply ndn.ReplyFunc, extra ndn.InterestHandlerExtra, matching enc.Matching,
 ) {
 	context := Context{
 		CkInterest:   interest,
-		CkDeadline:   deadline,
-		CkRawPacket:  rawInterest,
-		CkSigCovered: sigCovered,
+		CkDeadline:   extra.Deadline,
+		CkRawPacket:  extra.RawInterest,
+		CkSigCovered: extra.SigCovered,
 		CkName:       interest.Name(),
 		CkEngine:     n.engine,
 		CkContent:    interest.AppParam(),
@@ -78,7 +77,7 @@ func (n *ExpressPoint) OnInterest(
 			validRes := VrSilence
 			context[CkLastValidResult] = validRes
 			for _, evt := range n.onValidateInt.val {
-				res := (*evt)(matching, interest.Name(), interest.Signature(), sigCovered, context)
+				res := (*evt)(matching, interest.Name(), interest.Signature(), extra.SigCovered, context)
 				if res < VrSilence {
 					n.Log.WithField("name", interest.Name().String()).Warn("Verification failed for Interest. Drop.")
 					return

--- a/pkg/schema_old/helper.go
+++ b/pkg/schema_old/helper.go
@@ -1,4 +1,4 @@
-package schema
+package schema_old
 
 import (
 	"fmt"

--- a/pkg/schema_old/interface.go
+++ b/pkg/schema_old/interface.go
@@ -1,4 +1,4 @@
-package schema
+package schema_old
 
 import (
 	"time"
@@ -50,8 +50,8 @@ type NTNode interface {
 	ConstructName(matching enc.Matching, ret enc.Name) error
 
 	// OnInterest is the callback function when there is an incoming Interest.
-	OnInterest(interest ndn.Interest, rawInterest enc.Wire, sigCovered enc.Wire,
-		reply ndn.ReplyFunc, deadline time.Time, matching enc.Matching)
+	OnInterest(interest ndn.Interest, reply ndn.ReplyFunc,
+		extra ndn.InterestHandlerExtra, matching enc.Matching)
 
 	// OnAttach is called when the node is attached to an engine
 	OnAttach(path enc.NamePattern, engine ndn.Engine) error

--- a/pkg/schema_old/leaf_node.go
+++ b/pkg/schema_old/leaf_node.go
@@ -1,4 +1,4 @@
-package schema
+package schema_old
 
 import (
 	"time"

--- a/pkg/schema_old/tree.go
+++ b/pkg/schema_old/tree.go
@@ -1,9 +1,8 @@
-package schema
+package schema_old
 
 import (
 	"errors"
 	"sync"
-	"time"
 
 	enc "github.com/zjkmxy/go-ndn/pkg/encoding"
 	"github.com/zjkmxy/go-ndn/pkg/log"
@@ -65,8 +64,9 @@ func (t *Tree) Match(name enc.Name) (NTNode, enc.Matching) {
 }
 
 func (t *Tree) intHandler(
-	interest ndn.Interest, rawInterest enc.Wire, sigCovered enc.Wire,
-	reply ndn.ReplyFunc, deadline time.Time,
+	interest ndn.Interest,
+	reply ndn.ReplyFunc,
+	extra ndn.InterestHandlerExtra,
 ) {
 	t.lock.RLock()
 	defer t.lock.RUnlock()
@@ -91,7 +91,7 @@ func (t *Tree) intHandler(
 			matching["sha256digest"] = extraComp.Val
 		}
 	}
-	node.OnInterest(interest, rawInterest, sigCovered, reply, deadline, matching)
+	node.OnInterest(interest, reply, extra, matching)
 }
 
 // At the path return the node. Path does not include the attached prefix.

--- a/pkg/security/ndncert_0_3/zz_generated.go
+++ b/pkg/security/ndncert_0_3/zz_generated.go
@@ -325,10 +325,11 @@ func (context *CaProfileParsingContext) Parse(reader enc.ParseReader, ignoreCrit
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 129:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.CaPrefix = make(enc.Name, l/2+1)
 					startName := reader.Pos()
@@ -353,7 +354,7 @@ func (context *CaProfileParsingContext) Parse(reader enc.ParseReader, ignoreCrit
 
 				}
 			case 131:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					{
 						var builder strings.Builder
@@ -365,7 +366,7 @@ func (context *CaProfileParsingContext) Parse(reader enc.ParseReader, ignoreCrit
 
 				}
 			case 133:
-				if progress+1 == 2 {
+				if true {
 					handled = true
 					if value.ParamKey == nil {
 						value.ParamKey = make([]string, 0)
@@ -392,7 +393,7 @@ func (context *CaProfileParsingContext) Parse(reader enc.ParseReader, ignoreCrit
 
 				}
 			case 139:
-				if progress+1 == 3 {
+				if true {
 					handled = true
 					value.MaxValidPeriod = uint64(0)
 					{
@@ -410,7 +411,7 @@ func (context *CaProfileParsingContext) Parse(reader enc.ParseReader, ignoreCrit
 					}
 				}
 			case 137:
-				if progress+1 == 4 {
+				if true {
 					handled = true
 					value.CaCert, err = reader.ReadWire(int(l))
 
@@ -441,21 +442,7 @@ func (context *CaProfileParsingContext) Parse(reader enc.ParseReader, ignoreCrit
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 5; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.CaPrefix = nil
-		case 1 - 1:
-			err = enc.ErrSkipRequired{Name: "CaInfo", TypeNum: 131}
-		case 2 - 1:
 
-		case 3 - 1:
-			err = enc.ErrSkipRequired{Name: "MaxValidPeriod", TypeNum: 139}
-		case 4 - 1:
-			value.CaCert = nil
-		}
-	}
 	if err != nil {
 		return nil, err
 	}
@@ -672,10 +659,11 @@ func (context *ProbeIntAppParamParsingContext) Parse(reader enc.ParseReader, ign
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 133:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					if value.Params == nil {
 						value.Params = make(map[string][]byte)
@@ -736,13 +724,7 @@ func (context *ProbeIntAppParamParsingContext) Parse(reader enc.ParseReader, ign
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 1; progress++ {
-		switch progress {
-		case 0 - 1:
 
-		}
-	}
 	if err != nil {
 		return nil, err
 	}
@@ -907,10 +889,11 @@ func (context *ProbeResParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 7:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.Response = make(enc.Name, l/2+1)
 					startName := reader.Pos()
@@ -954,15 +937,7 @@ func (context *ProbeResParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 2; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.Response = nil
-		case 1 - 1:
-			value.MaxSuffixLength = nil
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -1145,10 +1120,11 @@ func (context *ProbeResContentParsingContext) Parse(reader enc.ParseReader, igno
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 141:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					if value.Vals == nil {
 						value.Vals = make([]*ProbeRes, 0)
@@ -1185,13 +1161,7 @@ func (context *ProbeResContentParsingContext) Parse(reader enc.ParseReader, igno
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 1; progress++ {
-		switch progress {
-		case 0 - 1:
 
-		}
-	}
 	if err != nil {
 		return nil, err
 	}
@@ -1349,17 +1319,18 @@ func (context *CmdNewIntParsingContext) Parse(reader enc.ParseReader, ignoreCrit
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 145:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.EcdhPub = make([]byte, l)
 					_, err = io.ReadFull(reader, value.EcdhPub)
 
 				}
 			case 147:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					value.CertReq = make([]byte, l)
 					_, err = io.ReadFull(reader, value.CertReq)
@@ -1385,15 +1356,7 @@ func (context *CmdNewIntParsingContext) Parse(reader enc.ParseReader, ignoreCrit
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 2; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.EcdhPub = nil
-		case 1 - 1:
-			value.CertReq = nil
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -1683,31 +1646,32 @@ func (context *CmdNewDataParsingContext) Parse(reader enc.ParseReader, ignoreCri
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 145:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.EcdhPub = make([]byte, l)
 					_, err = io.ReadFull(reader, value.EcdhPub)
 
 				}
 			case 149:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					value.Salt = make([]byte, l)
 					_, err = io.ReadFull(reader, value.Salt)
 
 				}
 			case 151:
-				if progress+1 == 2 {
+				if true {
 					handled = true
 					value.ReqId = make([]byte, l)
 					_, err = io.ReadFull(reader, value.ReqId)
 
 				}
 			case 153:
-				if progress+1 == 3 {
+				if true {
 					handled = true
 					if value.Challenge == nil {
 						value.Challenge = make([]string, 0)
@@ -1757,19 +1721,7 @@ func (context *CmdNewDataParsingContext) Parse(reader enc.ParseReader, ignoreCri
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 4; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.EcdhPub = nil
-		case 1 - 1:
-			value.Salt = nil
-		case 2 - 1:
-			value.ReqId = nil
-		case 3 - 1:
 
-		}
-	}
 	if err != nil {
 		return nil, err
 	}
@@ -1966,24 +1918,25 @@ func (context *CipherMsgParsingContext) Parse(reader enc.ParseReader, ignoreCrit
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 157:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.InitVec = make([]byte, l)
 					_, err = io.ReadFull(reader, value.InitVec)
 
 				}
 			case 175:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					value.AuthNTag = make([]byte, l)
 					_, err = io.ReadFull(reader, value.AuthNTag)
 
 				}
 			case 159:
-				if progress+1 == 2 {
+				if true {
 					handled = true
 					value.Payload = make([]byte, l)
 					_, err = io.ReadFull(reader, value.Payload)
@@ -2011,17 +1964,7 @@ func (context *CipherMsgParsingContext) Parse(reader enc.ParseReader, ignoreCrit
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 3; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.InitVec = nil
-		case 1 - 1:
-			value.AuthNTag = nil
-		case 2 - 1:
-			value.Payload = nil
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -2274,10 +2217,11 @@ func (context *ChallengeIntPlainParsingContext) Parse(reader enc.ParseReader, ig
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 161:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					{
 						var builder strings.Builder
@@ -2289,7 +2233,7 @@ func (context *ChallengeIntPlainParsingContext) Parse(reader enc.ParseReader, ig
 
 				}
 			case 133:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					if value.Params == nil {
 						value.Params = make(map[string][]byte)
@@ -2352,15 +2296,7 @@ func (context *ChallengeIntPlainParsingContext) Parse(reader enc.ParseReader, ig
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 2; progress++ {
-		switch progress {
-		case 0 - 1:
-			err = enc.ErrSkipRequired{Name: "SelectedChal", TypeNum: 161}
-		case 1 - 1:
 
-		}
-	}
 	if err != nil {
 		return nil, err
 	}
@@ -2820,10 +2756,11 @@ func (context *ChallengeDataPlainParsingContext) Parse(reader enc.ParseReader, i
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 155:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.Status = uint64(0)
 					{
@@ -2841,7 +2778,7 @@ func (context *ChallengeDataPlainParsingContext) Parse(reader enc.ParseReader, i
 					}
 				}
 			case 163:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					{
 						var builder strings.Builder
@@ -2854,7 +2791,7 @@ func (context *ChallengeDataPlainParsingContext) Parse(reader enc.ParseReader, i
 
 				}
 			case 165:
-				if progress+1 == 2 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -2877,7 +2814,7 @@ func (context *ChallengeDataPlainParsingContext) Parse(reader enc.ParseReader, i
 
 				}
 			case 167:
-				if progress+1 == 3 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -2900,7 +2837,7 @@ func (context *ChallengeDataPlainParsingContext) Parse(reader enc.ParseReader, i
 
 				}
 			case 169:
-				if progress+1 == 4 {
+				if true {
 					handled = true
 					value.CertName = make(enc.Name, l/2+1)
 					startName := reader.Pos()
@@ -2925,7 +2862,7 @@ func (context *ChallengeDataPlainParsingContext) Parse(reader enc.ParseReader, i
 
 				}
 			case 30:
-				if progress+1 == 5 {
+				if true {
 					handled = true
 					value.ForwardingHint = make(enc.Name, l/2+1)
 					startName := reader.Pos()
@@ -2950,7 +2887,7 @@ func (context *ChallengeDataPlainParsingContext) Parse(reader enc.ParseReader, i
 
 				}
 			case 133:
-				if progress+1 == 6 {
+				if true {
 					handled = true
 					if value.Params == nil {
 						value.Params = make(map[string][]byte)
@@ -3023,25 +2960,7 @@ func (context *ChallengeDataPlainParsingContext) Parse(reader enc.ParseReader, i
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 7; progress++ {
-		switch progress {
-		case 0 - 1:
-			err = enc.ErrSkipRequired{Name: "Status", TypeNum: 155}
-		case 1 - 1:
-			value.ChalStatus = nil
-		case 2 - 1:
-			value.RemainTries = nil
-		case 3 - 1:
-			value.RemainTime = nil
-		case 4 - 1:
-			value.CertName = nil
-		case 5 - 1:
-			value.ForwardingHint = nil
-		case 6 - 1:
 
-		}
-	}
 	if err != nil {
 		return nil, err
 	}
@@ -3189,10 +3108,11 @@ func (context *ErrorMsgDataParsingContext) Parse(reader enc.ParseReader, ignoreC
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 171:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.ErrCode = uint64(0)
 					{
@@ -3210,7 +3130,7 @@ func (context *ErrorMsgDataParsingContext) Parse(reader enc.ParseReader, ignoreC
 					}
 				}
 			case 173:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					{
 						var builder strings.Builder
@@ -3241,15 +3161,7 @@ func (context *ErrorMsgDataParsingContext) Parse(reader enc.ParseReader, ignoreC
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 2; progress++ {
-		switch progress {
-		case 0 - 1:
-			err = enc.ErrSkipRequired{Name: "ErrCode", TypeNum: 171}
-		case 1 - 1:
-			err = enc.ErrSkipRequired{Name: "ErrInfo", TypeNum: 173}
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/tests/encoding/gen_basic/definition.go
+++ b/tests/encoding/gen_basic/definition.go
@@ -34,7 +34,7 @@ type WireNameField struct {
 	Name enc.Name `tlv:"0x02"`
 }
 
-//+tlv-model:private
+// +tlv-model:private,ordered
 type Markers struct {
 	//+field:offsetMarker
 	startMarker enc.PlaceHolder
@@ -76,7 +76,7 @@ func ParseMarkers(buf []byte, arg int) *Markers {
 	}
 }
 
-//+tlv-model:nocopy
+// +tlv-model:nocopy
 type NoCopyStruct struct {
 	//+field:wire
 	Wire1 enc.Wire `tlv:"0x01"`

--- a/tests/encoding/gen_basic/zz_generated.go
+++ b/tests/encoding/gen_basic/zz_generated.go
@@ -172,10 +172,11 @@ func (context *FakeMetaInfoParsingContext) Parse(reader enc.ParseReader, ignoreC
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 24:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.Number = uint64(0)
 					{
@@ -193,7 +194,7 @@ func (context *FakeMetaInfoParsingContext) Parse(reader enc.ParseReader, ignoreC
 					}
 				}
 			case 25:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					{
 						timeInt := uint64(0)
@@ -216,7 +217,7 @@ func (context *FakeMetaInfoParsingContext) Parse(reader enc.ParseReader, ignoreC
 
 				}
 			case 26:
-				if progress+1 == 2 {
+				if true {
 					handled = true
 					value.Binary = make([]byte, l)
 					_, err = io.ReadFull(reader, value.Binary)
@@ -244,17 +245,7 @@ func (context *FakeMetaInfoParsingContext) Parse(reader enc.ParseReader, ignoreC
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 3; progress++ {
-		switch progress {
-		case 0 - 1:
-			err = enc.ErrSkipRequired{Name: "Number", TypeNum: 24}
-		case 1 - 1:
-			err = enc.ErrSkipRequired{Name: "Time", TypeNum: 25}
-		case 2 - 1:
-			value.Binary = nil
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -459,10 +450,11 @@ func (context *OptFieldParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 24:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -485,7 +477,7 @@ func (context *OptFieldParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 
 				}
 			case 25:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					{
 						timeInt := uint64(0)
@@ -509,14 +501,14 @@ func (context *OptFieldParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 
 				}
 			case 26:
-				if progress+1 == 2 {
+				if true {
 					handled = true
 					value.Binary = make([]byte, l)
 					_, err = io.ReadFull(reader, value.Binary)
 
 				}
 			case 48:
-				if progress+1 == 3 {
+				if true {
 					handled = true
 					value.Bool = true
 				}
@@ -544,19 +536,7 @@ func (context *OptFieldParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 4; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.Number = nil
-		case 1 - 1:
-			value.Time = nil
-		case 2 - 1:
-			value.Binary = nil
-		case 3 - 1:
-			value.Bool = false
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -733,16 +713,17 @@ func (context *WireNameFieldParsingContext) Parse(reader enc.ParseReader, ignore
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 1:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.Wire, err = reader.ReadWire(int(l))
 
 				}
 			case 2:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					value.Name = make(enc.Name, l/2+1)
 					startName := reader.Pos()
@@ -786,15 +767,7 @@ func (context *WireNameFieldParsingContext) Parse(reader enc.ParseReader, ignore
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 2; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.Wire = nil
-		case 1 - 1:
-			value.Name = nil
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -989,7 +962,7 @@ func (context *MarkersParsingContext) Parse(reader enc.ParseReader, ignoreCritic
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		for handled := false; !handled && progress < 5; progress++ {
 			switch typ {
 			case 1:
 				if progress+1 == 1 {
@@ -1063,6 +1036,7 @@ func (context *MarkersParsingContext) Parse(reader enc.ParseReader, ignoreCritic
 			context.endMarker = int(startPos)
 		}
 	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -1350,16 +1324,17 @@ func (context *NoCopyStructParsingContext) Parse(reader enc.ParseReader, ignoreC
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 1:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.Wire1, err = reader.ReadWire(int(l))
 
 				}
 			case 2:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					value.Number = uint64(0)
 					{
@@ -1377,7 +1352,7 @@ func (context *NoCopyStructParsingContext) Parse(reader enc.ParseReader, ignoreC
 					}
 				}
 			case 3:
-				if progress+1 == 2 {
+				if true {
 					handled = true
 					value.Wire2, err = reader.ReadWire(int(l))
 
@@ -1404,17 +1379,7 @@ func (context *NoCopyStructParsingContext) Parse(reader enc.ParseReader, ignoreC
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 3; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.Wire1 = nil
-		case 1 - 1:
-			err = enc.ErrSkipRequired{Name: "Number", TypeNum: 2}
-		case 2 - 1:
-			value.Wire2 = nil
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -1568,10 +1533,11 @@ func (context *StrFieldParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 1:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					{
 						var builder strings.Builder
@@ -1583,7 +1549,7 @@ func (context *StrFieldParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 
 				}
 			case 2:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					{
 						var builder strings.Builder
@@ -1615,15 +1581,7 @@ func (context *StrFieldParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 2; progress++ {
-		switch progress {
-		case 0 - 1:
-			err = enc.ErrSkipRequired{Name: "Str1", TypeNum: 1}
-		case 1 - 1:
-			value.Str2 = nil
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -1743,10 +1701,11 @@ func (context *FixedUintFieldParsingContext) Parse(reader enc.ParseReader, ignor
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 1:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.Byte, err = reader.ReadByte()
 
@@ -1758,7 +1717,7 @@ func (context *FixedUintFieldParsingContext) Parse(reader enc.ParseReader, ignor
 
 				}
 			case 2:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					{
 						tempVal := uint32(0)
@@ -1781,7 +1740,7 @@ func (context *FixedUintFieldParsingContext) Parse(reader enc.ParseReader, ignor
 
 				}
 			case 3:
-				if progress+1 == 2 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -1825,17 +1784,7 @@ func (context *FixedUintFieldParsingContext) Parse(reader enc.ParseReader, ignor
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 3; progress++ {
-		switch progress {
-		case 0 - 1:
-			err = enc.ErrSkipRequired{Name: "Byte", TypeNum: 1}
-		case 1 - 1:
-			value.U32 = nil
-		case 2 - 1:
-			value.U64 = nil
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/tests/encoding/gen_composition/zz_generated.go
+++ b/tests/encoding/gen_composition/zz_generated.go
@@ -155,10 +155,11 @@ func (context *IntArrayParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 1:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					if value.Words == nil {
 						value.Words = make([]uint64, 0)
@@ -208,13 +209,7 @@ func (context *IntArrayParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 1; progress++ {
-		switch progress {
-		case 0 - 1:
 
-		}
-	}
 	if err != nil {
 		return nil, err
 	}
@@ -399,10 +394,11 @@ func (context *NameArrayParsingContext) Parse(reader enc.ParseReader, ignoreCrit
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 7:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					if value.Names == nil {
 						value.Names = make([]enc.Name, 0)
@@ -459,13 +455,7 @@ func (context *NameArrayParsingContext) Parse(reader enc.ParseReader, ignoreCrit
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 1; progress++ {
-		switch progress {
-		case 0 - 1:
 
-		}
-	}
 	if err != nil {
 		return nil, err
 	}
@@ -578,10 +568,11 @@ func (context *InnerParsingContext) Parse(reader enc.ParseReader, ignoreCritical
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 1:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.Num = uint64(0)
 					{
@@ -616,13 +607,7 @@ func (context *InnerParsingContext) Parse(reader enc.ParseReader, ignoreCritical
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 1; progress++ {
-		switch progress {
-		case 0 - 1:
-			err = enc.ErrSkipRequired{Name: "Num", TypeNum: 1}
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -748,10 +733,11 @@ func (context *NestedParsingContext) Parse(reader enc.ParseReader, ignoreCritica
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 2:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.Val, err = context.Val_context.Parse(reader.Delegate(int(l)), ignoreCritical)
 				}
@@ -773,13 +759,7 @@ func (context *NestedParsingContext) Parse(reader enc.ParseReader, ignoreCritica
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 1; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.Val = nil
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -962,10 +942,11 @@ func (context *NestedSeqParsingContext) Parse(reader enc.ParseReader, ignoreCrit
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 3:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					if value.Vals == nil {
 						value.Vals = make([]*Inner, 0)
@@ -1002,13 +983,7 @@ func (context *NestedSeqParsingContext) Parse(reader enc.ParseReader, ignoreCrit
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 1; progress++ {
-		switch progress {
-		case 0 - 1:
 
-		}
-	}
 	if err != nil {
 		return nil, err
 	}
@@ -1235,16 +1210,17 @@ func (context *InnerWire1ParsingContext) Parse(reader enc.ParseReader, ignoreCri
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 1:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.Wire1, err = reader.ReadWire(int(l))
 
 				}
 			case 2:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					{
 						tempVal := uint64(0)
@@ -1286,15 +1262,7 @@ func (context *InnerWire1ParsingContext) Parse(reader enc.ParseReader, ignoreCri
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 2; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.Wire1 = nil
-		case 1 - 1:
-			value.Num = nil
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -1454,10 +1422,11 @@ func (context *InnerWire2ParsingContext) Parse(reader enc.ParseReader, ignoreCri
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 3:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.Wire2, err = reader.ReadWire(int(l))
 
@@ -1480,13 +1449,7 @@ func (context *InnerWire2ParsingContext) Parse(reader enc.ParseReader, ignoreCri
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 1; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.Wire2 = nil
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -1808,15 +1771,16 @@ func (context *NestedWireParsingContext) Parse(reader enc.ParseReader, ignoreCri
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 4:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.W1, err = context.W1_context.Parse(reader.Delegate(int(l)), ignoreCritical)
 				}
 			case 5:
-				if progress+1 == 1 {
+				if true {
 					handled = true
 					value.N = uint64(0)
 					{
@@ -1834,7 +1798,7 @@ func (context *NestedWireParsingContext) Parse(reader enc.ParseReader, ignoreCri
 					}
 				}
 			case 6:
-				if progress+1 == 2 {
+				if true {
 					handled = true
 					value.W2, err = context.W2_context.Parse(reader.Delegate(int(l)), ignoreCritical)
 				}
@@ -1860,17 +1824,7 @@ func (context *NestedWireParsingContext) Parse(reader enc.ParseReader, ignoreCri
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 3; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.W1 = nil
-		case 1 - 1:
-			err = enc.ErrSkipRequired{Name: "N", TypeNum: 5}
-		case 2 - 1:
-			value.W2 = nil
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/tests/encoding/gen_map/zz_generated.go
+++ b/tests/encoding/gen_map/zz_generated.go
@@ -203,10 +203,11 @@ func (context *StringMapParsingContext) Parse(reader enc.ParseReader, ignoreCrit
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 133:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					if value.Params == nil {
 						value.Params = make(map[string][]byte)
@@ -267,13 +268,7 @@ func (context *StringMapParsingContext) Parse(reader enc.ParseReader, ignoreCrit
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 1; progress++ {
-		switch progress {
-		case 0 - 1:
 
-		}
-	}
 	if err != nil {
 		return nil, err
 	}
@@ -386,10 +381,11 @@ func (context *InnerParsingContext) Parse(reader enc.ParseReader, ignoreCritical
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 1:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					value.Num = uint64(0)
 					{
@@ -424,13 +420,7 @@ func (context *InnerParsingContext) Parse(reader enc.ParseReader, ignoreCritical
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 1; progress++ {
-		switch progress {
-		case 0 - 1:
-			err = enc.ErrSkipRequired{Name: "Num", TypeNum: 1}
-		}
-	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -653,10 +643,11 @@ func (context *IntStructMapParsingContext) Parse(reader enc.ParseReader, ignoreC
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 133:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					if value.Params == nil {
 						value.Params = make(map[uint64]*Inner)
@@ -721,13 +712,7 @@ func (context *IntStructMapParsingContext) Parse(reader enc.ParseReader, ignoreC
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 1; progress++ {
-		switch progress {
-		case 0 - 1:
 
-		}
-	}
 	if err != nil {
 		return nil, err
 	}

--- a/tests/encoding/gen_signature/definition.go
+++ b/tests/encoding/gen_signature/definition.go
@@ -8,7 +8,7 @@ import (
 	enc "github.com/zjkmxy/go-ndn/pkg/encoding"
 )
 
-//+tlv-model:nocopy,private
+// +tlv-model:nocopy,private,ordered
 type T1 struct {
 	//+field:natural
 	H1 uint64 `tlv:"0x01"`
@@ -52,7 +52,7 @@ func ReadT1(reader enc.ParseReader) (*T1, enc.Wire, error) {
 	return ret, context.sigCovered, nil
 }
 
-//+tlv-model:nocopy,private
+// +tlv-model:nocopy,private
 type T2 struct {
 	//+field:interestName:sigCovered
 	Name enc.Name `tlv:"0x01"`

--- a/tests/encoding/gen_signature/zz_generated.go
+++ b/tests/encoding/gen_signature/zz_generated.go
@@ -360,7 +360,7 @@ func (context *T1ParsingContext) Parse(reader enc.ParseReader, ignoreCritical bo
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		for handled := false; !handled && progress < 6; progress++ {
 			switch typ {
 			case 1:
 				if progress+1 == 0 {
@@ -464,6 +464,7 @@ func (context *T1ParsingContext) Parse(reader enc.ParseReader, ignoreCritical bo
 
 		}
 	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -839,10 +840,11 @@ func (context *T2ParsingContext) Parse(reader enc.ParseReader, ignoreCritical bo
 			return nil, enc.ErrFailToParse{TypeNum: 0, Err: err}
 		}
 		err = nil
-		for handled := false; !handled; progress++ {
+		if true {
+			handled := false
 			switch typ {
 			case 1:
-				if progress+1 == 0 {
+				if true {
 					handled = true
 					{
 						value.Name = make(enc.Name, l/2+1)
@@ -878,13 +880,13 @@ func (context *T2ParsingContext) Parse(reader enc.ParseReader, ignoreCritical bo
 
 				}
 			case 3:
-				if progress+1 == 3 {
+				if true {
 					handled = true
 					value.C, err = reader.ReadWire(int(l))
 
 				}
 			case 4:
-				if progress+1 == 4 {
+				if true {
 					handled = true
 					value.Sig, err = reader.ReadWire(int(l))
 					if err == nil {
@@ -923,25 +925,7 @@ func (context *T2ParsingContext) Parse(reader enc.ParseReader, ignoreCritical bo
 			}
 		}
 	}
-	startPos = reader.Pos()
-	for ; progress < 7; progress++ {
-		switch progress {
-		case 0 - 1:
-			value.Name = nil
-		case 1 - 1:
-			context.sigCoverStart = int(startPos)
-		case 2 - 1:
-			context.digestCoverStart = int(startPos)
-		case 3 - 1:
-			value.C = nil
-		case 4 - 1:
-			value.Sig = nil
-		case 5 - 1:
-			context.digestCoverEnd = int(startPos)
-		case 6 - 1:
 
-		}
-	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Each commit should be reviewed individuall (git(hub) sucks, I miss phabricator ...)

1. Simplifies low-level API for interest
2. Adds incoming face ID to interest callback (needed for router)
3. Adds ExecMgmtCommand to engine to make it easy to set strategy etc
4. The one for codegen I'm not sure about. From my understanding, the TLV is parsed in order for the signature / digest placeholders etc. But this creates problems if the ordering is not right. The packet below (generated by NFD) doesn't parse content (it's a mgmt command) and goes into an infinite loop.

```
06fd0100074b08096c6f63616c686f737408036e6664080566616365730806757064617465080868066c01017001010220bdb073d28481e6a84102c50f8e55d8131c8c6c701c4a23f059a17c77e84356cf1404190203e8152565236601c867024f4b681a6902010c6c0105850101870405f5e10088040001000089022260163b1b01031c36073408096c6f63616c686f737408086f70657261746f7208034b45590808a11aeb12c383f307080473656c66360800000193a5aa2eb217473045022100c4b45a58e4e957511d4c16ea55fe46576e87d3e53b0b83a1d98308c9dfbf9f1c022044696e214189763c94f83f016bf7b422133b78610cbfb821634058cd1bc89d43
```

My fix in this PR (which seems to work) is to add another attribute `ordered` to the struct, but only for the structs that actually care about ordering for signature / digest (e.g. Interest / Data packets etc.). For the rest, it gets rid of the `progress` variable and parses the subblock directly. I've many questions ...