### PR TITLE
codegen: parse *byte directly to wire address

### DIFF
--- a/pkg/encoding/codegen/fields.go
+++ b/pkg/encoding/codegen/fields.go
@@ -913,16 +913,22 @@ func (f *FixedUintField) GenReadFrom() (string, error) {
 
 	if f.opt {
 		g.printlnf("{")
-		g.printlnf("tempVal := %s(0)", digit)
-		gen("tempVal")
-		g.printlnf("value.%s = &tempVal", f.name)
-		g.printlnf("}")
 
 		// Special case for a single byte - directly use wire address
 		// This is useful to modify the TLV in-place (e.g. HopLimit)
 		if f.l == 1 {
+			g.printlnf("err = reader.Skip(1)")
+			g.printlnf("if err == io.EOF {")
+			g.printlnf("err = io.ErrUnexpectedEOF")
+			g.printlnf("}")
 			g.printlnf("value.%s = &reader.Range(reader.Pos()-1, reader.Pos())[0][0]", f.name)
+		} else {
+			g.printlnf("tempVal := %s(0)", digit)
+			gen("tempVal")
+			g.printlnf("value.%s = &tempVal", f.name)
 		}
+
+		g.printlnf("}")
 	} else {
 		gen("value." + f.name)
 	}

--- a/pkg/encoding/codegen/fields.go
+++ b/pkg/encoding/codegen/fields.go
@@ -880,10 +880,10 @@ func (f *FixedUintField) GenReadFrom() (string, error) {
 
 	gen := func(name string) {
 		if f.l == 1 {
-			g.printlnf("%s, err = reader.ReadByte()\n", name)
-			g.printlnf("if err == io.EOF {\n")
-			g.printlnf("\terr = io.ErrUnexpectedEOF\n")
-			g.printlnf("}\n")
+			g.printlnf("%s, err = reader.ReadByte()", name)
+			g.printlnf("if err == io.EOF {")
+			g.printlnf("err = io.ErrUnexpectedEOF")
+			g.printlnf("}")
 		} else {
 			const Temp = `{{.Name}} = {{.Digit}}(0)
 			{
@@ -915,9 +915,14 @@ func (f *FixedUintField) GenReadFrom() (string, error) {
 		g.printlnf("{")
 		g.printlnf("tempVal := %s(0)", digit)
 		gen("tempVal")
-		g.printlnf("value." + f.name + " = &tempVal")
+		g.printlnf("value.%s = &tempVal", f.name)
 		g.printlnf("}")
-		return g.output()
+
+		// Special case for a single byte - directly use wire address
+		// This is useful to modify the TLV in-place (e.g. HopLimit)
+		if f.l == 1 {
+			g.printlnf("value.%s = &reader.Range(reader.Pos()-1, reader.Pos())[0][0]", f.name)
+		}
 	} else {
 		gen("value." + f.name)
 	}

--- a/pkg/ndn/spec_2022/zz_generated.go
+++ b/pkg/ndn/spec_2022/zz_generated.go
@@ -3936,14 +3936,12 @@ func (context *InterestParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 				if progress+1 == 8 {
 					handled = true
 					{
-						tempVal := byte(0)
-						tempVal, err = reader.ReadByte()
+						err = reader.Skip(1)
 						if err == io.EOF {
 							err = io.ErrUnexpectedEOF
 						}
-						value.HopLimitV = &tempVal
+						value.HopLimitV = &reader.Range(reader.Pos()-1, reader.Pos())[0][0]
 					}
-					value.HopLimitV = &reader.Range(reader.Pos()-1, reader.Pos())[0][0]
 
 				}
 			case 36:

--- a/pkg/ndn/spec_2022/zz_generated.go
+++ b/pkg/ndn/spec_2022/zz_generated.go
@@ -3938,15 +3938,12 @@ func (context *InterestParsingContext) Parse(reader enc.ParseReader, ignoreCriti
 					{
 						tempVal := byte(0)
 						tempVal, err = reader.ReadByte()
-
 						if err == io.EOF {
-
 							err = io.ErrUnexpectedEOF
-
 						}
-
 						value.HopLimitV = &tempVal
 					}
+					value.HopLimitV = &reader.Range(reader.Pos()-1, reader.Pos())[0][0]
 
 				}
 			case 36:

--- a/tests/encoding/gen_basic/zz_generated.go
+++ b/tests/encoding/gen_basic/zz_generated.go
@@ -1708,11 +1708,8 @@ func (context *FixedUintFieldParsingContext) Parse(reader enc.ParseReader, ignor
 				if true {
 					handled = true
 					value.Byte, err = reader.ReadByte()
-
 					if err == io.EOF {
-
 						err = io.ErrUnexpectedEOF
-
 					}
 
 				}


### PR DESCRIPTION
This is needed to update the HopLimit without re-encoding the interest in YaNFD.