### PR TITLE
name: use pool for hash objects 

### DIFF
--- a/pkg/encoding/name_pattern.go
+++ b/pkg/encoding/name_pattern.go
@@ -2,10 +2,10 @@ package encoding
 
 import (
 	"crypto/sha256"
+	"hash"
 	"io"
 	"strings"
 
-	"github.com/cespare/xxhash"
 	"github.com/zjkmxy/go-ndn/pkg/utils"
 )
 
@@ -101,7 +101,9 @@ func (n Name) Bytes() []byte {
 
 // Hash returns the hash of the name
 func (n Name) Hash() uint64 {
-	h := xxhash.New()
+	h := hashPool.Get().(hash.Hash64)
+	defer hashPool.Put(h)
+	h.Reset()
 	for _, c := range n {
 		c.HashInto(h)
 	}
@@ -111,8 +113,10 @@ func (n Name) Hash() uint64 {
 // PrefixHash returns the hash value of all prefixes of the name
 // ret[n] means the hash of the prefix of length n. ret[0] is the same for all names.
 func (n Name) PrefixHash() []uint64 {
+	h := hashPool.Get().(hash.Hash64)
+	defer hashPool.Put(h)
+	h.Reset()
 	ret := make([]uint64, len(n)+1)
-	h := xxhash.New()
 	ret[0] = h.Sum64()
 	for i, c := range n {
 		c.HashInto(h)


### PR DESCRIPTION
Stacked on #11 

xxhash::New() puts surprisingly significant gc pressure, since we call this very often.

![image](https://github.com/user-attachments/assets/5174aa67-ea6d-409b-93f0-3a309e2f9bc2)
